### PR TITLE
Add bulleted list, and add language hint to rouge.

### DIFF
--- a/_posts/2025-04-07-Cell-Constraint-Dungeon-Generation.markdown
+++ b/_posts/2025-04-07-Cell-Constraint-Dungeon-Generation.markdown
@@ -93,11 +93,11 @@ How we choose which rooms to add to the candidacy list depends on where we are i
   * We may only drop a small number of rooms during the finish-up phase, or we could have quite a few rooms left to place to finish up. There’s a lot of variance during this phase.  
   * During this wrap up phase, we also add the special rooms into the mix, so that they more likely show up at the edges of the dungeon
 
-For each candidate room:  
-	For each orientation:  
-		If it works, place the room  
-	If no orientation works, discard the room and get a new one from the list  
-If there are no rooms left, put this particular cell back into the ***back*** of the queue and we’ll get to it later. *This can happen for large dungeons if the generator is still in growth mode, but the cell requires an exact placement*.
+* For each candidate room:  
+	* For each orientation:  
+		* If it works, place the room  
+	* If no orientation works, discard the room and get a new one from the list  
+* If there are no rooms left, put this particular cell back into the ***back*** of the queue and we’ll get to it later. *This can happen for large dungeons if the generator is still in growth mode, but the cell requires an exact placement*.
 
 ## Placing Rooms
 
@@ -161,7 +161,7 @@ One very important thing to note though is the rotation directions\! In Godot, 2
 
 # The Code
 
-```
+```gdscript
 @tool
 extends Node
 class_name DungeonLayoutGenerator


### PR DESCRIPTION
The indents were consumed by markdown and didn't persist - so I changed it to bullets.

https://rouge-ruby.github.io/docs/file.Languages.html
Rouge claims to support gdscript text highlighting, so let's see how that goes.