### PR TITLE
Feature: Iterative loop

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"2c431c2f-bcfe-4fbf-90da-a0a5000d7582","pid":10750,"acquiredAt":1776546269487}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"2c431c2f-bcfe-4fbf-90da-a0a5000d7582","pid":10750,"acquiredAt":1776546269487}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tools/gba_convert/**/__pycache__/
 tools/gba_convert/.venv/
 # *.gba
 # *.GBA
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ _site
 .jekyll-metadata
 
 config.codekit
+
+# gba_convert pipeline
+tools/gba_convert/output/
+tools/gba_convert/output.*/
+tools/gba_convert/**/__pycache__/
+tools/gba_convert/.venv/
+*.gba
+*.GBA

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ tools/gba_convert/output/
 tools/gba_convert/output.*/
 tools/gba_convert/**/__pycache__/
 tools/gba_convert/.venv/
-*.gba
-*.GBA
+# *.gba
+# *.GBA

--- a/tools/gba_convert/CLAUDE.md
+++ b/tools/gba_convert/CLAUDE.md
@@ -1,0 +1,193 @@
+# GBA Disassembly Analysis Agent
+
+You are analysing ARMv4 / THUMB assembly produced by Luvdis from a Game Boy
+Advance ROM. Your job is to turn raw assembly into human-readable
+documentation: inline `@` comments on the code, plus structured entries
+for `variables.md` and `functions.cfg`.
+
+---
+
+## Hard rules
+
+1. **Never invent addresses, symbol names, or constants that don't appear
+   in the input.** If you don't know, say so (`@ purpose unclear`).
+2. **Stay consistent across modules.** If `variables.md` already names
+   function `sub_080024C0` as `AgbMain`, use `AgbMain` in the new module
+   — don't re-guess.
+3. **Comments are short.** Prefer `@ poll joypad` to three lines of prose.
+4. **The annotated `.s` output must still assemble.** Do not modify
+   instruction lines, labels, or directives — only add `@` comments on
+   their own line or at the end of an existing line.
+5. **Structured output only** — responses must match the JSON schema in
+   the prompt, nothing else.
+
+---
+
+## GBA memory map (annotate accesses against this)
+
+| Range                         | Region          | Notes                                  |
+|-------------------------------|-----------------|----------------------------------------|
+| `0x00000000` – `0x00003FFF`   | BIOS            | Not readable from user code            |
+| `0x02000000` – `0x0203FFFF`   | EWRAM (256 KB)  | Work RAM, 2-cycle access               |
+| `0x03000000` – `0x03007FFF`   | IWRAM (32 KB)   | Fast work RAM, 1-cycle                 |
+| `0x04000000` – `0x040003FE`   | I/O registers   | See REG table below                    |
+| `0x05000000` – `0x050003FF`   | Palette RAM     | 256×16-bit BG + 256×16-bit OBJ         |
+| `0x06000000` – `0x06017FFF`   | VRAM (96 KB)    | BG + OBJ tile + map data               |
+| `0x07000000` – `0x070003FF`   | OAM             | 128 sprite entries × 8 bytes           |
+| `0x08000000` – `0x09FFFFFF`   | Game Pak ROM    | Wait-state 0 — the game code           |
+| `0x0A000000` – `0x0DFFFFFF`   | Game Pak ROM    | Mirrors with different wait states     |
+| `0x0E000000` – `0x0E00FFFF`   | Game Pak SRAM   | Save data                              |
+
+When you see `ldr`/`str` against one of these ranges, mention the region
+in the comment (`@ write to VRAM tile base`, `@ load save byte`, etc.).
+
+---
+
+## Key I/O registers (annotate by name, not address)
+
+| Addr        | Name            | Purpose                               |
+|-------------|-----------------|---------------------------------------|
+| `0x4000000` | REG_DISPCNT     | LCD control (mode, BG/OBJ enable)     |
+| `0x4000004` | REG_DISPSTAT    | Display status / V-blank flags        |
+| `0x4000006` | REG_VCOUNT      | Current scanline                      |
+| `0x4000008` | REG_BG0CNT      | BG 0 control                          |
+| `0x400000A` | REG_BG1CNT      | BG 1 control                          |
+| `0x400000C` | REG_BG2CNT      | BG 2 control                          |
+| `0x400000E` | REG_BG3CNT      | BG 3 control                          |
+| `0x4000130` | REG_KEYINPUT    | Joypad (active-low)                   |
+| `0x4000132` | REG_KEYCNT      | Joypad IRQ control                    |
+| `0x4000200` | REG_IE          | Interrupt enable                      |
+| `0x4000202` | REG_IF          | Interrupt flags (ack by writing)      |
+| `0x4000208` | REG_IME         | Master interrupt enable               |
+| `0x40000B0` | REG_DMA0SAD     | DMA 0 source                          |
+| `0x40000BC` | REG_DMA1SAD     | DMA 1 source                          |
+| `0x40000C8` | REG_DMA2SAD     | DMA 2 source                          |
+| `0x40000D4` | REG_DMA3SAD     | DMA 3 source (general-purpose)        |
+| `0x4000100` | REG_TM0CNT_L    | Timer 0 count                         |
+
+This is a short list — if an access hits `0x04000xxx` and you can't
+identify the exact register, say `@ I/O reg (unknown)` and move on.
+
+---
+
+## BIOS / SWI call table
+
+SWI immediates on GBA. Annotate `swi 0xNN` lines with the call name.
+
+| SWI    | Name            | Notes                                  |
+|--------|-----------------|----------------------------------------|
+| `0x00` | SoftReset       |                                        |
+| `0x01` | RegisterRamReset|                                        |
+| `0x02` | Halt            |                                        |
+| `0x03` | Stop            |                                        |
+| `0x04` | IntrWait        |                                        |
+| `0x05` | VBlankIntrWait  | Most common — frame wait               |
+| `0x06` | Div             | r0 = num, r1 = denom                   |
+| `0x07` | DivArm          |                                        |
+| `0x08` | Sqrt            |                                        |
+| `0x09` | ArcTan          |                                        |
+| `0x0A` | ArcTan2         |                                        |
+| `0x0B` | CpuSet          | 32-bit fixed-size copy/fill            |
+| `0x0C` | CpuFastSet      | 32-byte-block copy/fill                |
+| `0x0D` | GetBiosChecksum |                                        |
+| `0x0E` | BgAffineSet     |                                        |
+| `0x0F` | ObjAffineSet    |                                        |
+| `0x10` | BitUnPack       |                                        |
+| `0x11` | LZ77UnCompWRAM  |                                        |
+| `0x12` | LZ77UnCompVRAM  |                                        |
+| `0x13` | HuffUnComp      |                                        |
+| `0x14` | RLUnCompWRAM    |                                        |
+| `0x15` | RLUnCompVRAM    |                                        |
+| `0x16` | Diff8bitUnFilterWRAM |                                   |
+| `0x17` | Diff8bitUnFilterVRAM |                                   |
+| `0x18` | Diff16bitUnFilter |                                      |
+| `0x19` | SoundBias       |                                        |
+| `0x1A` | SoundDriverInit |                                        |
+| `0x1B` | SoundDriverMode |                                        |
+| `0x1C` | SoundDriverMain |                                        |
+| `0x1D` | SoundDriverVSync|                                        |
+| `0x1E` | SoundChannelClear|                                       |
+| `0x1F` | MidiKey2Freq    |                                        |
+| `0x25` | MultiBoot       |                                        |
+| `0x27` | HardReset       |                                        |
+| `0x2A` | SoundDriverVSyncOff |                                    |
+
+---
+
+## Calling convention (AAPCS, GBA flavour)
+
+- **Args:** `r0`–`r3`, then stack.
+- **Return:** `r0` (+ `r1` for 64-bit).
+- **Scratch:** `r0`–`r3`, `r12`, `lr` (within a call).
+- **Callee-saved:** `r4`–`r11`.
+- **THUMB ↔ ARM:** calls across modes go via `bx` / `blx`. `bx lr`
+  returns; if the low bit of `lr` is set, you're returning to THUMB.
+
+When annotating a function entry, note which registers are used for
+arguments (based on how they're consumed before being written) and what
+`r0` looks like at exit. Don't guess at types.
+
+---
+
+## How to annotate (style guide)
+
+Good:
+
+```
+    push {r4, lr}           @ save frame
+    ldr  r0, =0x04000130    @ REG_KEYINPUT
+    ldrh r0, [r0]           @ read joypad
+    bl   sub_080012C4       @ UpdatePlayerInput
+```
+
+Bad (don't do this):
+
+```
+    @ This line pushes r4 and the link register onto the stack,
+    @ which is how ARM functions preserve their frame before doing
+    @ any work. After this, we will then load an address...
+```
+
+- One short comment per line, only where it adds info.
+- If a whole block does one thing, put a one-line `@ ---- <summary>`
+  above it instead of commenting every line.
+- Never annotate obvious instructions (`mov r0, #0  @ set r0 to zero`).
+
+---
+
+## What to promote to `variables.md`
+
+For each module, emit entries (as JSON — see prompt template) for:
+
+- **Functions** you confidently name: `sub_<ADDR>` → human name + one-line
+  description + arg/return summary.
+- **Globals** — RAM addresses written from multiple call sites, or read
+  in a way that implies they're state (loop counters, flags, pointers).
+  Include: address, inferred type (`u8`/`u16`/`u32`/`ptr`), purpose.
+- **I/O writes** worth highlighting — e.g. "configures mode 0 with BG0+BG1".
+- **Constants / magic numbers** that clearly encode game meaning (frame
+  counts, damage tables, etc.).
+
+Don't emit an entry you can't justify from the code in front of you.
+
+---
+
+## What to promote to `functions.cfg`
+
+Only confidently-named functions, in Luvdis config format:
+
+```
+thumb_func 0x0800024C AgbMain
+arm_func   0x080000D0 RomHeader_Entry
+```
+
+Guessed-but-uncertain names stay as `sub_<ADDR>` — do not write them to
+`functions.cfg` (they'll churn on every run).
+
+---
+
+## When in doubt
+
+Prefer silence over speculation. An unannotated line is fine; a
+confidently-wrong annotation pollutes `variables.md` and misleads every
+subsequent module.

--- a/tools/gba_convert/PROCESS.md
+++ b/tools/gba_convert/PROCESS.md
@@ -1,0 +1,456 @@
+# GBA ROM → Annotated Disassembly + C View Pipeline
+
+End-to-end process for taking a raw GBA ROM, disassembling it with Luvdis,
+splitting the result into LLM-sized chunks, driving an agentic analysis
+pass that produces human-readable annotations + a memory/variable map,
+and translating each annotated module into **C pseudocode** that is both
+easier for an LLM to read and — crucially — editable + re-compilable via
+`arm-none-eabi-gcc` for surgical ROM edits.
+
+Two round-trippable loops:
+
+- **ROM ↔ ASM** — Luvdis output reassembles to an identical ROM.
+- **C → ASM → ROM** — only for _edited_ functions; the rest of the ROM
+  stays verbatim from Luvdis. See §11.
+
+We chose C over Python because:
+
+1. C's semantics (fixed-width ints, raw pointers, no GC) match ARMv4
+   almost 1:1. Python doesn't.
+2. `arm-none-eabi-gcc` actually exists and compiles C to ARMv4-THUMB.
+   No equivalent Python-to-ARMv4 compiler exists.
+3. The original GBA games were (mostly) compiled _from_ C. Going back
+   to C is reversing the original compilation direction, not inventing
+   a new one.
+4. LLM-driven edits in C are cheaper (fewer tokens per logical operation
+   than ASM) and more reliable (LLMs reason about C far better than
+   about register-level ARM).
+
+---
+
+## 1. Goals
+
+Given a `*.gba` ROM, produce:
+
+1. **`rom.s`** — raw Luvdis disassembly (full ROM).
+2. **`modules/mod_<ADDR>.s`** — the same disassembly split into smaller logical
+   files, each small enough to fit in a single LLM prompt (~1–2k lines).
+3. **`annotated/mod_<ADDR>.s`** — per-module copy with inline comments:
+   - BIOS/SWI call identification (`swi 0x6` → `Div`, etc.)
+   - Likely function purpose ("reads joypad", "copies tiles to VRAM")
+   - Register usage notes on entry/exit
+4. **`variables.md`** — discovered globals, RAM layout, I/O-register usage,
+   constants, and any function-name guesses promoted to canonical names.
+5. **`functions.cfg`** — Luvdis config file of discovered/named functions,
+   usable for re-disassembling with better labels.
+6. **`c_view/mod_<ADDR>.c`** + **`c_view/gba.h`** — C translation of
+   each annotated module. Function/variable names come from
+   `variables.md`, so the C reads like ordinary code rather than
+   register soup. This is also the **edit surface** for LLM-driven ROM
+   modifications (§11).
+7. **`rebuilt.gba`** (future) — a round-tripped ROM built from the
+   original disassembly with any edited C functions surgically spliced
+   in, verified by hash. _Implemented in `rebuild.py` + `recompile.py`;
+   see §11._
+
+Items 4, 5, and 6 are the comprehension deliverables. Item 7 closes the
+ROM-editing loop — edits land in C, get compiled back to ASM, and are
+spliced into the full disassembly for reassembly.
+
+---
+
+## 2. Prerequisites
+
+- Python 3.8+ (Luvdis requires 3.6+; we use modern typing).
+- Local Luvdis checkout at `../../luvdis/` (already present in this repo).
+  We invoke it via `python -m luvdis` with `PYTHONPATH` pointed at that dir —
+  no `pip install` required.
+- A GBA ROM file (user-provided; not committed to the repo).
+- LLM access — **open decision**, see §7.
+
+Dependencies for the orchestrator itself are pinned in
+`tools/gba_convert/requirements.txt` (click, tqdm inherited from Luvdis;
+`anthropic` only if we go the API route).
+
+---
+
+## 3. Directory Layout
+
+```text
+tools/gba_convert/
+├── PROCESS.md              ← this file
+├── CLAUDE.md               ← system prompt for analysis + C-view agents
+├── README.md               ← quick-start
+├── requirements.txt
+├── pipeline.py             ← top-level orchestrator (CLI entrypoint)
+├── disassemble.py          ← step 1: run Luvdis
+├── split_modules.py        ← step 2: chunk rom.s into modules/
+├── analyze.py              ← step 3: annotate ASM, build variables.md
+├── translate_to_c.py       ← step 4: annotated ASM → C
+├── recompile.py            ← (future) edited C → fresh ASM → splice
+├── rebuild.py              ← (future) rebuild .gba from spliced ASM
+├── prompts/
+│   ├── module_analysis.md  ← prompt for step 3
+│   └── c_view.md           ← prompt for step 4
+└── output/
+    ├── rom.s
+    ├── rom.info.txt            ← `luvdis info` output (hash, detected title)
+    ├── modules/
+    │   └── mod_08000000.s
+    ├── annotated/
+    │   └── mod_08000000.s      ← ASM with @-comments (step 3 output)
+    ├── c_view/
+    │   ├── gba.h               ← shared defs (REG_*, u8/u16/u32, SWI wrappers)
+    │   └── mod_08000000.c      ← C translation (step 4 output)
+    ├── variables.md            ← accumulated across runs
+    ├── functions.cfg           ← accumulated across runs
+    ├── edited/
+    │   └── mod_08000000.c      ← (future) user-edited copies
+    ├── recompiled/
+    │   └── mod_08000000.s      ← (future) gcc output, spliced into annotated/
+    └── rebuilt.gba             ← (future) output of rebuild.py
+```
+
+`output/` is gitignored. The ROM itself must **never** be committed.
+
+---
+
+## 4. Pipeline Steps
+
+### Step 1 — Disassemble (`disassemble.py`)
+
+**Input:** `<rom>.gba`
+**Output:** `output/rom.s`, `output/rom.info.txt`, `output/functions.cfg` (seed)
+
+Actions:
+1. Run `luvdis info <rom>` → capture ROM hash + detected title.
+2. Run `luvdis disasm <rom> -o output/rom.s -co output/functions.cfg`
+   with `--default-mode BYTE` (safe default; can be overridden per-ROM).
+3. If a previous `output/functions.cfg` exists, pass it back in via `-c`
+   so that human-named functions survive re-runs.
+
+We shell out to Luvdis via `subprocess` rather than importing it, so that
+the Luvdis codebase stays untouched and can be swapped for a pip install
+later without code changes.
+
+### Step 2 — Split into Modules (`split_modules.py`)
+
+**Input:** `output/rom.s`
+**Output:** `output/modules/mod_<HEX_ADDR>.s`
+
+Luvdis emits `.s` with interleaved code + data. The splitter walks the file
+and cuts on these boundaries:
+
+- Every `thumb_func`/`arm_func`/`non_word_aligned_thumb_func` directive.
+- Large `.byte`/`.word` data blocks (≥ N bytes) — these become their own
+  "data-only" modules tagged `mod_<ADDR>.data.s`.
+- Size ceiling: if an accumulating chunk exceeds `--max-lines` (default
+  1500), emit it at the next function boundary.
+
+Each output file carries a header comment:
+
+```
+@ Module: mod_080002A0.s
+@ Range:  0x080002A0 – 0x08000C14
+@ Source: output/rom.s lines 1204–2739
+@ Kind:   code | data | mixed
+```
+
+This header is what the analysis step keys on to know the memory range it's
+looking at.
+
+### Step 3 — Agentic Analysis (`analyze.py`)
+
+**Input:** `output/modules/*.s` + `output/variables.md` (accumulating)
+**Output:** `output/annotated/*.s`, updated `output/variables.md`,
+            updated `output/functions.cfg`
+
+For each module (in address order):
+
+1. Load the module file + `CLAUDE.md` system prompt + current
+   `variables.md` (as context — keeps previously-discovered names
+   consistent).
+2. Send to the LLM with the module-analysis prompt template.
+3. Expect a structured response containing:
+   - **annotated assembly** (original lines, with `@` comments added) —
+     written to `output/annotated/mod_<ADDR>.s`.
+   - **new variable / register / memory entries** — appended to
+     `variables.md` under the appropriate section.
+   - **function-name guesses** — merged into `functions.cfg` so that
+     the next re-disassembly picks them up.
+4. Rate-limit / checkpoint between modules so a failed run resumes
+   from the last completed module (via a `.progress.json` sidecar).
+
+Module ordering matters: we go low → high address so that early passes
+(entry point, BIOS init, main loop) populate `variables.md` before
+later game-logic modules consume it.
+
+### Step 4 — C View (`translate_to_c.py`)
+
+**Input:** `output/annotated/*.s` + `output/variables.md`
+**Output:** `output/c_view/*.c`, `output/c_view/gba.h`
+
+For each annotated module, produce a C file that reads the same
+behaviour as the assembly but in a form that's cheap for an LLM to
+reason about and — critically — compilable back to ARMv4-THUMB via
+`arm-none-eabi-gcc`. The C view is the preferred edit surface: edits
+made here can round-trip to a rebuilt ROM via §11.
+
+Per module:
+
+1. Load the annotated `.s` + `variables.md` + the C-view prompt.
+2. Ask the LLM to translate using names from `variables.md`, so that
+   `sub_08001234` becomes `update_player_input` (etc.).
+3. Expect a C file that:
+   - Starts with a header block tying it back to the source:
+     `/* @source: annotated/mod_0003_0800E1FC.s  0x0800E1FC–... */`.
+   - Uses `<stdint.h>` types (`uint8_t`, `int16_t`, `uint32_t`, …)
+     so LDR/STR widths are explicit.
+   - Uses the `REG_*` macros from `gba.h` (not raw addresses).
+   - Uses the SWI wrappers (`bios_div`, `bios_vblank_wait`, …) from
+     `gba.h` instead of inline `swi` asm.
+   - Carries `// asm:` backrefs on each non-trivial block so the
+     ASM↔C mapping is auditable.
+4. Write to `output/c_view/<same-basename>.c`.
+5. Checkpoint via `.progress_c.json` (separate from step 3 progress).
+
+`gba.h` is written once on the first run (idempotent). It contains:
+
+- Fixed-width typedefs (`u8`, `u16`, `u32`, `s8`, `s16`, `s32`).
+- `REG_*` macros for the I/O registers enumerated in `CLAUDE.md`.
+- BIOS SWI wrappers declared `extern` (the _definitions_ live in
+  the original ROM's BIOS-call stubs, which we don't touch).
+- Memory-region base address constants (`EWRAM_BASE`, `VRAM_BASE`, …).
+
+Step 4 depends on step 3 output — if annotations are thin the C is
+thin too. Run step 3 first, inspect `variables.md`, then translate.
+
+**Constraint discipline.** The C must compile with
+`arm-none-eabi-gcc -mthumb -Os -nostdlib -ffreestanding`. No libc, no
+heap allocation, no floating point unless the annotated ASM used the
+soft-float helpers. If an instruction has no clean C equivalent
+(e.g. SMLAL with specific flag behaviour the surrounding code
+depends on), emit a GCC inline-asm block rather than fabricate
+wrong C.
+
+---
+
+## 5. `CLAUDE.md` (analysis agent instructions)
+
+A separate file; not yet written. It will instruct the analysis agent to:
+
+- Identify **GBA BIOS calls** (`swi` immediates 0x00–0x2A) by their known
+  names and document the calling convention used.
+- Recognise **memory-mapped I/O** accesses to `0x04000000–0x040003FE`
+  (REG_DISPCNT, REG_KEYINPUT, DMA regs, timers, sound) and annotate.
+- Recognise **memory regions** by address prefix: ROM (`0x08…`),
+  EWRAM (`0x02…`), IWRAM (`0x03…`), VRAM (`0x06…`), OAM (`0x07…`),
+  palette RAM (`0x05…`), save (`0x0E…`).
+- Produce **stable function names** — same behaviour across modules must
+  get the same name. Use `variables.md` as the source of truth.
+- Prefer **short `@` comments** over verbose prose; assembly stays readable.
+- Never invent addresses or symbol names that aren't derivable from the
+  code shown.
+
+---
+
+## 6. Re-run Semantics
+
+The pipeline is idempotent w.r.t. a given ROM hash:
+
+- `output/rom.info.txt` is checked on every run. If the hash changes,
+  `output/` is archived to `output.<old-hash>/` before proceeding.
+- Step 2 is fully deterministic — same `rom.s` + same `--max-lines`
+  produces the same modules.
+- Step 3 is resumable via `.progress.json`; completed modules are
+  skipped unless `--force` is passed.
+
+This matters because step 3 is the expensive one (LLM calls), and
+iterating on the prompt should not require re-running steps 1–2.
+
+---
+
+## 7. Open Decisions
+
+**Blocker for implementation:**
+
+1. **LLM invocation.** Two options:
+   - **Anthropic API** (`anthropic` Python SDK) — needs
+     `ANTHROPIC_API_KEY`, gives us structured streaming, caching, usage
+     metrics. Better for batch pipelines.
+   - **Claude Code CLI** — shell out to `claude -p "<prompt>"`. No key
+     needed, but harder to parse structured output and to parallelise.
+
+   _Recommendation:_ API. Prompt caching over `CLAUDE.md` +
+   `variables.md` is a big win when processing hundreds of modules.
+
+**Not blockers, but worth deciding:**
+
+2. **Default-mode for Luvdis** (`BYTE` vs `THUMB`). `BYTE` is safer but
+   produces huge data blocks; `THUMB` gets cleaner output on code-heavy
+   ROMs. Start with `BYTE`, expose a CLI flag.
+3. **Max lines per module.** Default 1500; tune after first real run.
+4. **Parallelism.** Step 3 is embarrassingly parallel per-module, but
+   `variables.md` is shared mutable state. Either serialize, or do two
+   passes (pass 1: independent annotation; pass 2: reconciliation).
+
+---
+
+## 8. Out of Scope (for v1)
+
+- Graphics/tileset extraction (separate tool).
+- Script/text extraction (needs charmap knowledge per-game).
+- Web UI / visualisation of the memory map.
+- **Whole-ROM rebuild from C.** We only recompile _edited_ functions;
+  the rest of the ROM comes from Luvdis's matching disassembly. See §10
+  for why, and §11 for how the surgical splice works.
+
+---
+
+## 9. Success Criteria
+
+**Milestone 1 — analysis works end-to-end.** Run on the provided ROM
+and produce a `variables.md` that identifies:
+
+- The entry point and `AgbMain`.
+- The main game loop.
+- Every BIOS SWI actually called.
+- The I/O register writes that configure the display mode.
+
+**Milestone 2 — C view works end-to-end.** For each annotated module,
+produce a `c_view/*.c` that:
+
+- Compiles with `arm-none-eabi-gcc -mthumb -Os -nostdlib -ffreestanding
+  -c mod_XXXX.c`. (The result isn't expected to be byte-identical to
+  the original; just "it compiles and produces code of a sane size".)
+- References names from `variables.md` consistently.
+- Carries `// asm:` backref comments on every non-trivial block.
+- Compiles against the shared `c_view/gba.h`.
+
+**Milestone 3 — unmodified ROM round-trip via ASM.** `python rebuild.py`
+produces a `rebuilt.gba` whose SHA-1 matches `rom.hash.txt` exactly,
+built from `annotated/*.s` alone (no C recompile). This proves the
+assembly toolchain is wired correctly.
+
+**Milestone 4 — surgical C edit round-trip.** Edit one function in
+`edited/mod_XXXX.c`, run `recompile.py` to splice in the new bytes,
+then `rebuild.py`. Result is a new ROM that:
+
+- Differs from the original by _exactly_ the edited function's byte
+  range (diffing `rebuilt.gba` against the original shows bytes changed
+  only in that region).
+- Boots on `mGBA` (or similar) and exhibits the edited behaviour.
+
+Anything beyond these is iteration on the prompts.
+
+---
+
+## 10. Why the C view is editable, and what that means
+
+C is an impedance match for ARMv4-THUMB in a way Python (or any
+garbage-collected language) isn't:
+
+| Concern            | ARMv4 / GBA                           | C                              | Python                |
+|--------------------|---------------------------------------|--------------------------------|-----------------------|
+| Integers           | Fixed 8/16/32-bit, wrap on overflow   | Same (`uint8_t` etc.)          | Arbitrary precision   |
+| Memory model       | Raw pointers, MMIO                    | Same                           | GC'd objects          |
+| Calling convention | AAPCS                                 | GCC emits AAPCS by default     | Name-based            |
+| Control flow       | Cond flags, jumps, LDM/STM            | `if`/`for`, compiler-generated | `if`/`for`/exceptions |
+| Compiler to ARMv4  | (n/a — is the target)                 | `arm-none-eabi-gcc`            | does not exist        |
+
+Because `arm-none-eabi-gcc` compiles C to ARMv4-THUMB, **edited C can
+round-trip to the ROM** — but with two important caveats:
+
+1. **Not byte-identical.** GCC will compile a given C function to ASM
+   that _does the same thing_ but differs in register allocation,
+   instruction ordering, and sometimes peephole choices. So the bytes
+   of a recompiled function won't match the original unless the
+   original was compiled from the exact same C with the exact same
+   toolchain version (rarely true for retail ROMs).
+2. **We therefore only recompile _edited_ functions.** Unchanged
+   regions of the ROM are taken verbatim from the Luvdis disassembly,
+   which _is_ byte-identical. The rebuild process (§11) splices the
+   recompiled edited-function bytes into the original byte stream,
+   leaving everything else untouched.
+
+This gives us a practical edit loop:
+
+- Read a function in C (cheaper tokens, easier for LLMs to modify).
+- Edit the C.
+- `recompile.py` compiles only that function and splices the result
+  back into `annotated/*.s`.
+- `rebuild.py` produces a new `.gba`.
+
+The untouched 99% of the ROM comes from the original disassembly, so
+the only bytes that change are inside the edited function's range. If
+the edited function's new compiled size _exceeds_ the original slot,
+`recompile.py` fails loudly rather than silently overflowing — the
+user has to either shrink the edit or provide a trampoline (§11).
+
+The C view is allowed to _lose information_ that isn't load-bearing:
+LDM ordering, register numbers, literal-pool layout. If the ASM has
+semantics that C can't express cleanly (rare — specific CPSR flag
+behaviour, interleaved loads for pipeline timing), the translator
+drops to GCC inline `__asm__` rather than fabricating wrong C.
+
+---
+
+## 11. ROM round-trip — ASM alone + surgical C splice
+
+Two future scripts close the loop: `rebuild.py` for the pure ASM round
+trip, and `recompile.py` for the C-edit splice that sits in front of it.
+
+### 11a. Pure ASM round trip (`rebuild.py`)
+
+Luvdis's output is deliberately designed to reassemble to an identical
+ROM. Pipeline:
+
+1. `arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork` — assemble each
+   `.s` in `annotated/` → `.o`.
+2. `arm-none-eabi-ld -T linker.ld` — link with a script anchored at
+   `0x08000000`.
+3. `arm-none-eabi-objcopy -O binary` — strip ELF → `rebuilt.gba`.
+4. `gbafix rebuilt.gba` — recompute the ROM header checksum.
+5. Compare SHA-1 of `rebuilt.gba` against `rom.hash.txt`. Identical
+   hash = disassembly is matching.
+
+Requires the ARM bare-metal toolchain:
+
+- macOS: `brew install --cask gcc-arm-embedded` + `brew install gbafix`
+- Linux: `apt install gcc-arm-none-eabi` (+ `gbafix` from pip/source).
+
+This step is independent of step 4 — annotations are `@` comments and
+don't affect the assembled bytes.
+
+### 11b. Surgical C edit splice (`recompile.py`)
+
+Takes edited C in `output/edited/mod_XXXX.c` and reflows it back into
+`annotated/` without disturbing surrounding bytes:
+
+1. Identify which functions in the C file differ from `c_view/` (the
+   unedited translation). Only those are recompiled.
+2. For each edited function `foo` at original address `0x080XXXXX`
+   with original byte length `N`:
+   1. Compile the one function:
+      `arm-none-eabi-gcc -mthumb -Os -nostdlib -ffreestanding -c
+      -o foo.o edited/mod_XXXX.c`.
+   2. Extract `foo`'s section from the `.o` via `objdump` + `objcopy`.
+   3. Compare the new byte length `N'` against the original `N`.
+      - If `N' <= N`: pad the tail with NOPs to preserve the address
+        map. Safe splice.
+      - If `N' > N`: fail loudly. The user must either shrink the edit,
+        bump to a larger slot manually, or introduce a trampoline
+        (jump to a fresh region of ROM). v1 doesn't auto-trampoline —
+        that's a whole bin-packing problem.
+3. Write the patched ASM to `output/recompiled/mod_XXXX.s`. This is
+   then picked up by `rebuild.py` instead of the original `annotated/`
+   version for those modules.
+4. Emit a diff report listing every changed function, its address
+   range, and its new vs. old size.
+
+The property we preserve: **bytes outside edited functions stay
+byte-identical to the original ROM**. That's why the new ROM is a
+controlled delta, not a recompile of the whole game.
+
+Status of both scripts: not yet implemented. Stubs will be placed so
+the directory layout is ready.

--- a/tools/gba_convert/README.md
+++ b/tools/gba_convert/README.md
@@ -1,0 +1,122 @@
+# gba_convert
+
+A four-step pipeline that takes a GBA ROM and produces:
+
+1. An annotated, re-assemblable disassembly.
+2. A memory / variable map (`variables.md`).
+3. A C translation of each module (editable, compilable via
+   `arm-none-eabi-gcc` — the edit surface for surgical ROM mods).
+
+Future scripts (`recompile.py`, `rebuild.py`) close the loop:
+edit the C, splice the recompiled function back into the disassembly,
+and produce a new `.gba` that differs from the original by exactly
+the bytes you changed.
+
+See [PROCESS.md](PROCESS.md) for the full design doc, including why
+C (not Python) for the intermediate representation.
+
+---
+
+## Quick start
+
+```sh
+cd tools/gba_convert
+
+# 1. Set up a venv (Luvdis + Anthropic SDK)
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e ../../luvdis   # the bundled Luvdis checkout
+
+# 2. Point at your ROM
+export ANTHROPIC_API_KEY=sk-...
+python pipeline.py path/to/your_rom.gba
+```
+
+Output lands in `output/`:
+
+```text
+output/
+├── rom.s                ← raw Luvdis disassembly
+├── rom.info.txt         ← ROM hash + detected title
+├── rom.hash.txt
+├── modules/
+│   ├── _index.json
+│   └── mod_0000_08000000.s ...
+├── annotated/
+│   └── mod_0000_08000000.s ...     ← ASM + @ comments (step 3)
+├── c_view/
+│   ├── gba.h                        ← shared C defs (REG_*, u8/u16/u32, SWI wrappers)
+│   └── mod_0000_08000000.c ...     ← C translation (step 4)
+├── variables.md         ← growing memory / function map
+├── functions.cfg        ← Luvdis config of named functions
+├── .progress.json       ← resumable analyze state
+└── .progress_c.json     ← resumable C-view state
+```
+
+---
+
+## Running individual steps
+
+```sh
+python pipeline.py rom.gba --only disasm           # just re-run Luvdis
+python pipeline.py rom.gba --only split            # just re-chunk rom.s
+python pipeline.py rom.gba --only analyze          # step 3 only (ASM annotate)
+python pipeline.py rom.gba --only cview            # step 4 only (→ C)
+python pipeline.py rom.gba --skip-analyze          # disasm + split, no LLM
+python pipeline.py rom.gba --skip-cview            # disasm + split + analyze
+python pipeline.py rom.gba --only cview --force    # redo completed modules
+```
+
+Each LLM step is idempotent — `.progress.json` tracks step 3, and
+`.progress_c.json` tracks step 4. Delete the relevant file (or pass
+`--force`) to redo that pass.
+
+---
+
+## Tuning
+
+- `--default-mode BYTE|THUMB|WORD` — Luvdis's fallback for unknown
+  addresses. `BYTE` is safe; `THUMB` gives cleaner output on code-heavy
+  ROMs but can mis-disassemble data.
+- `--max-lines 1500` — max lines per module chunk. Smaller = more LLM
+  calls but better focus; larger = cheaper but risks hitting context
+  limits on complex modules.
+- `--model claude-opus-4-7` — any Anthropic model ID. Haiku is fine for
+  a first cheap pass; switch to Opus for real analysis.
+
+---
+
+## Changing a ROM
+
+If you run `pipeline.py` against a different ROM than last time, the
+existing `output/` is auto-archived to `output.<shortsha>/` so previous
+runs aren't clobbered.
+
+---
+
+## What's not included (yet)
+
+- **`recompile.py`** — compile an edited C module via
+  `arm-none-eabi-gcc` and splice the fresh bytes into the disassembly.
+  See [PROCESS.md §11b](PROCESS.md).
+- **`rebuild.py`** — `arm-none-eabi-as` / `ld` / `objcopy` / `gbafix`
+  to produce a `.gba` from the (possibly spliced) disassembly. See
+  [PROCESS.md §11a](PROCESS.md).
+- Graphics / tileset / text extraction — separate tools.
+
+---
+
+## Files
+
+| File                         | Purpose                                    |
+|------------------------------|--------------------------------------------|
+| `pipeline.py`                | CLI orchestrator                           |
+| `disassemble.py`             | Step 1 — wraps local Luvdis                |
+| `split_modules.py`           | Step 2 — chunks rom.s                      |
+| `analyze.py`                 | Step 3 — ASM annotation via Claude         |
+| `translate_to_c.py`          | Step 4 — ASM → C via Claude                |
+| `CLAUDE.md`                  | System prompt for analysis + C-view agents |
+| `prompts/module_analysis.md` | Per-module prompt for step 3               |
+| `prompts/c_view.md`          | Per-module prompt for step 4               |
+| `PROCESS.md`                 | Full design doc                            |

--- a/tools/gba_convert/README.md
+++ b/tools/gba_convert/README.md
@@ -1,16 +1,11 @@
 # gba_convert
 
-A four-step pipeline that takes a GBA ROM and produces:
+An end-to-end pipeline that takes a GBA ROM, produces a readable C view
+of every function, lets you edit the C (in code or via natural language),
+and splices the recompiled bytes back into a working `.gba`.
 
-1. An annotated, re-assemblable disassembly.
-2. A memory / variable map (`variables.md`).
-3. A C translation of each module (editable, compilable via
-   `arm-none-eabi-gcc` — the edit surface for surgical ROM mods).
-
-Future scripts (`recompile.py`, `rebuild.py`) close the loop:
-edit the C, splice the recompiled function back into the disassembly,
-and produce a new `.gba` that differs from the original by exactly
-the bytes you changed.
+The output is a **controlled-delta ROM**: unchanged regions stay
+byte-identical to the original; only the functions you touched change.
 
 See [PROCESS.md](PROCESS.md) for the full design doc, including why
 C (not Python) for the intermediate representation.
@@ -22,36 +17,118 @@ C (not Python) for the intermediate representation.
 ```sh
 cd tools/gba_convert
 
-# 1. Set up a venv (Luvdis + Anthropic SDK)
+# 1. Python deps (Luvdis + Anthropic SDK)
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 pip install -e ../../luvdis   # the bundled Luvdis checkout
 
-# 2. Point at your ROM
+# 2. Analysis only (Stage A) — no ARM toolchain needed
 export ANTHROPIC_API_KEY=sk-...
 python pipeline.py path/to/your_rom.gba
+
+# 3. (Optional) ARM toolchain, required only for edits + rebuild
+brew install --cask gcc-arm-embedded     # macOS
+brew install gbafix                       # optional, for header checksum
+
+# 4. Edit + rebuild
+python edit.py "bump max HP to 999"       # NL → edited/mod_*.c
+python recompile.py                        # splice compiled bytes
+python rebuild.py                          # → output/rebuilt.gba
 ```
 
-Output lands in `output/`:
+See [Output artifacts](#output-artifacts) for the full `output/` tree.
+
+---
+
+## Pipeline overview
+
+```mermaid
+flowchart TD
+    ROM["rom.gba"]:::io --> D[disassemble.py<br/><i>Luvdis</i>]
+    D -->|rom.s| S[split_modules.py]
+    S -->|modules/mod_*.s| A[analyze.py<br/><i>Claude</i>]
+    A -->|annotated/mod_*.s<br/>variables.md<br/>functions.cfg| T[translate_to_c.py<br/><i>Claude</i>]
+    T -->|c_view/mod_*.c<br/>c_view/gba.h| ED[edit.py<br/><i>Claude — NL</i>]
+    T -.->|hand-edit| MAN["edited/mod_*.c<br/>(direct code edit)"]:::io
+    ED -->|edited/mod_*.c| RC[recompile.py<br/><i>gcc + splice</i>]
+    MAN --> RC
+    RC -->|recompiled/mod_*.s| RB[rebuild.py<br/><i>as + ld + objcopy + gbafix</i>]
+    RB --> OUT["rebuilt.gba"]:::io
+
+    classDef io fill:#eef,stroke:#339,stroke-width:2px;
+```
+
+The arrows show data flow. Each box is a script; its label's italics
+note the external tool or model it drives. Everything left of the
+`c_view` boundary is **read-only analysis**; everything right of it is
+**surgical modification**.
+
+---
+
+## Components
+
+### Stage A — read-only analysis
+
+| Script | Input | Output | Role |
+|---|---|---|---|
+| [disassemble.py](disassemble.py) | `rom.gba` | `output/rom.s`, `rom.hash.txt`, `rom.info.txt` | Shells out to [Luvdis](../../luvdis) to produce a single ARMv4 / THUMB disassembly. Records the SHA-1 so later steps can verify round-trip. |
+| [split_modules.py](split_modules.py) | `output/rom.s` | `output/modules/mod_NNNN_ADDR.s` + `_index.json` | Cuts `rom.s` at function boundaries (`thumb_func_start`, `arm_func_start`) and at size-based fallback points. Each module is independently analyzable and labels its address range + `kind` (`code` / `data` / `mixed`). |
+| [analyze.py](analyze.py) | `modules/*.s` + `CLAUDE.md` + `prompts/module_analysis.md` | `annotated/*.s`, accumulating `variables.md` + `functions.cfg`, `.progress.json` | One Claude call per module. Adds `@` comments to the assembly, promotes confidently-named functions/globals/registers into `variables.md`, and writes high-confidence function addresses into `functions.cfg` (a Luvdis seed file). `kind == "data"` modules are skipped by default. |
+| [translate_to_c.py](translate_to_c.py) | `annotated/*.s` + `variables.md` + `prompts/c_view.md` | `c_view/*.c`, accumulating `c_view/gba.h`, `.progress_c.json` | One Claude call per annotated module. Produces C that compiles with `arm-none-eabi-gcc -mthumb -Os -nostdlib -ffreestanding`. The C uses types that preserve LDR/STR widths, names from `variables.md`, `REG_*` macros from `gba.h`, and `bios_*` SWI wrappers. Inline `__asm__` is used wherever C can't express ARM semantics. |
+
+### Stage B — editing
+
+| Script | Input | Output | Role |
+|---|---|---|---|
+| [edit.py](edit.py) | `"bump max HP to 999"` + `c_view/*.c` + `variables.md` | `edited/mod_*.c` | Two-stage Claude call. Stage 1 picks which module the instruction targets (from `variables.md` + the module list). Stage 2 rewrites that module under hard constraints (signatures immutable, `#include "gba.h"` only, must fit in original byte span). If `arm-none-eabi-gcc` rejects the output, stderr + the failed source are fed back and Claude retries up to 3 times. |
+| *(alternative)* direct edit | `cp c_view/X.c edited/X.c` + your editor | `edited/mod_*.c` | Skip `edit.py` entirely and write the C yourself. Anything in `edited/` that differs from its `c_view/` twin is picked up by `recompile.py`. |
+
+### Stage C — round trip
+
+| Script | Input | Output | Role |
+|---|---|---|---|
+| [recompile.py](recompile.py) | `edited/*.c` (diffed against `c_view/*.c`), `annotated/*.s` | `recompiled/mod_*.s`, `build_c/*.o`, `build_c/*.bin` | For each edited module: `gcc -c` → `objcopy --only-section=.text` → raw bytes. Locates the edited function's byte span in the annotated `.s`, checks the compiled length against the original (**fails if over-size** — the edit has to fit). Pads with THUMB nops (`0xC046`) if smaller. Splices those bytes back in, leaving the rest of the module byte-identical. |
+| [rebuild.py](rebuild.py) | `annotated/*.s` (or `recompiled/*.s` when present), [linker.ld](linker.ld) | `build/*.o`, `build/rebuilt.elf`, `output/rebuilt.gba` | `arm-none-eabi-as` each `.s` → `.o`, `ld -T linker.ld` → `elf`, `objcopy -O binary` → raw ROM, `gbafix` → correct header checksum, then SHA-1 verify against `rom.hash.txt`. An unspliced rebuild should match the original hash exactly — any drift is a Luvdis or toolchain bug. A spliced rebuild differs at exactly the edited byte spans. |
+
+### Support files
+
+| File | Role |
+|---|---|
+| [CLAUDE.md](CLAUDE.md) | Shared system prompt for all Claude calls. Contains the GBA memory map, I/O register table, SWI table, calling convention, and style rules. Cached via prompt caching. |
+| [prompts/module_analysis.md](prompts/module_analysis.md) | Per-module user prompt for `analyze.py`. |
+| [prompts/c_view.md](prompts/c_view.md) | Per-module user prompt for `translate_to_c.py`. |
+| [prompts/edit_target.md](prompts/edit_target.md) | Stage-1 user prompt for `edit.py` (target selection). |
+| [prompts/edit_apply.md](prompts/edit_apply.md) | Stage-2 user prompt for `edit.py` (apply + retry). |
+| [linker.ld](linker.ld) | Minimal GBA linker script. Places all module `.text` at `0x08000000` in the declaration order Luvdis emitted — which matches the original ROM layout. |
+| [PROCESS.md](PROCESS.md) | Full design doc (why C, surgical-splice model, §11a/§11b invariants). |
+
+### Output artifacts
 
 ```text
 output/
-├── rom.s                ← raw Luvdis disassembly
-├── rom.info.txt         ← ROM hash + detected title
-├── rom.hash.txt
+├── rom.s                   ← raw Luvdis disassembly
+├── rom.info.txt            ← detected ROM title
+├── rom.hash.txt            ← SHA-1 of the original ROM
 ├── modules/
-│   ├── _index.json
-│   └── mod_0000_08000000.s ...
-├── annotated/
-│   └── mod_0000_08000000.s ...     ← ASM + @ comments (step 3)
-├── c_view/
-│   ├── gba.h                        ← shared C defs (REG_*, u8/u16/u32, SWI wrappers)
-│   └── mod_0000_08000000.c ...     ← C translation (step 4)
-├── variables.md         ← growing memory / function map
-├── functions.cfg        ← Luvdis config of named functions
-├── .progress.json       ← resumable analyze state
-└── .progress_c.json     ← resumable C-view state
+│   ├── _index.json         ← manifest: path, addr_start, addr_end, kind
+│   └── mod_NNNN_ADDR.s
+├── annotated/              ← step 3: ASM + @ comments
+│   └── mod_NNNN_ADDR.s
+├── c_view/                 ← step 4: C edit surface
+│   ├── gba.h               ← shared defs (REG_*, u8/u16/u32, SWI wrappers)
+│   └── mod_NNNN_ADDR.c
+├── edited/                 ← YOUR edits (from edit.py or hand)
+│   └── mod_NNNN_ADDR.c
+├── recompiled/             ← recompile.py output (splice target)
+│   └── mod_NNNN_ADDR.s
+├── build_c/                ← gcc intermediates (per-module .o / .bin)
+├── build/                  ← as/ld intermediates (rebuilt.elf)
+├── rebuilt.gba             ← final rebuild
+├── variables.md            ← accumulating memory / function map
+├── functions.cfg           ← Luvdis config (high-confidence functions)
+├── .progress.json          ← resumable analyze state
+└── .progress_c.json        ← resumable C-view state
 ```
 
 ---
@@ -59,6 +136,7 @@ output/
 ## Running individual steps
 
 ```sh
+# --- Stage A: analysis ---
 python pipeline.py rom.gba --only disasm           # just re-run Luvdis
 python pipeline.py rom.gba --only split            # just re-chunk rom.s
 python pipeline.py rom.gba --only analyze          # step 3 only (ASM annotate)
@@ -66,6 +144,16 @@ python pipeline.py rom.gba --only cview            # step 4 only (→ C)
 python pipeline.py rom.gba --skip-analyze          # disasm + split, no LLM
 python pipeline.py rom.gba --skip-cview            # disasm + split + analyze
 python pipeline.py rom.gba --only cview --force    # redo completed modules
+python pipeline.py rom.gba --only analyze --limit 3  # smoke-test on 3 mods
+
+# --- Stage B: edits ---
+python edit.py "bump max HP to 999"                # NL → Claude picks target
+python edit.py --module mod_0017_080A1B30 "bump HP"  # NL on a known module
+
+# --- Stage C: round trip ---
+python recompile.py                                # compile edits + splice
+python rebuild.py                                  # → rebuilt.gba
+python rebuild.py --no-splice                      # rebuild from annotated/ only
 ```
 
 Each LLM step is idempotent — `.progress.json` tracks step 3, and
@@ -83,7 +171,12 @@ Each LLM step is idempotent — `.progress.json` tracks step 3, and
   calls but better focus; larger = cheaper but risks hitting context
   limits on complex modules.
 - `--model claude-opus-4-7` — any Anthropic model ID. Haiku is fine for
-  a first cheap pass; switch to Opus for real analysis.
+  a cheap triage pass on `analyze`; switch to Opus for `cview` and edits.
+- `--include-data` — by default, `kind == "data"` modules are skipped in
+  `analyze` and `cview` (no point sending `.byte` dumps to an LLM). Pass
+  this to process them anyway.
+- `--limit N` — process at most N modules in each LLM step. Useful for
+  smoke-testing the pipeline cheaply before a full run.
 
 ---
 
@@ -95,28 +188,36 @@ runs aren't clobbered.
 
 ---
 
-## What's not included (yet)
+## What's not included
 
-- **`recompile.py`** — compile an edited C module via
-  `arm-none-eabi-gcc` and splice the fresh bytes into the disassembly.
-  See [PROCESS.md §11b](PROCESS.md).
-- **`rebuild.py`** — `arm-none-eabi-as` / `ld` / `objcopy` / `gbafix`
-  to produce a `.gba` from the (possibly spliced) disassembly. See
-  [PROCESS.md §11a](PROCESS.md).
 - Graphics / tileset / text extraction — separate tools.
+- Multi-function-per-module edits — `recompile.py` assumes one edited
+  function per module. Editing two in the same module works only if
+  their combined size still fits the original span.
+- Relocation — if your edit doesn't fit in the original byte span,
+  `recompile.py` fails. There is no out-of-line trampoline path yet.
+- `.rodata` splicing — only `.text` is currently swapped back in. If an
+  edit introduces new read-only data, it'll be dropped at the
+  `objcopy --only-section=.text` step.
 
 ---
 
 ## Files
 
-| File                         | Purpose                                    |
-|------------------------------|--------------------------------------------|
-| `pipeline.py`                | CLI orchestrator                           |
-| `disassemble.py`             | Step 1 — wraps local Luvdis                |
-| `split_modules.py`           | Step 2 — chunks rom.s                      |
-| `analyze.py`                 | Step 3 — ASM annotation via Claude         |
-| `translate_to_c.py`          | Step 4 — ASM → C via Claude                |
-| `CLAUDE.md`                  | System prompt for analysis + C-view agents |
-| `prompts/module_analysis.md` | Per-module prompt for step 3               |
-| `prompts/c_view.md`          | Per-module prompt for step 4               |
-| `PROCESS.md`                 | Full design doc                            |
+| File                         | Purpose                                                |
+|------------------------------|--------------------------------------------------------|
+| `pipeline.py`                | CLI orchestrator (Stage A)                             |
+| `disassemble.py`             | Step 1 — wraps local Luvdis                            |
+| `split_modules.py`           | Step 2 — chunks rom.s                                  |
+| `analyze.py`                 | Step 3 — ASM annotation via Claude                     |
+| `translate_to_c.py`          | Step 4 — ASM → C via Claude                            |
+| `edit.py`                    | Stage B — natural-language edits via Claude + retry    |
+| `recompile.py`               | Stage C — compile edited C + splice bytes              |
+| `rebuild.py`                 | Stage C — `as` + `ld` + `objcopy` + `gbafix` → `.gba`  |
+| `linker.ld`                  | GBA linker script for `rebuild.py`                     |
+| `CLAUDE.md`                  | System prompt (shared across all Claude calls)         |
+| `prompts/module_analysis.md` | Per-module prompt for step 3                           |
+| `prompts/c_view.md`          | Per-module prompt for step 4                           |
+| `prompts/edit_target.md`     | Stage-1 prompt for `edit.py` (target selection)        |
+| `prompts/edit_apply.md`      | Stage-2 prompt for `edit.py` (apply + retry)           |
+| `PROCESS.md`                 | Full design doc                                        |

--- a/tools/gba_convert/analyze.py
+++ b/tools/gba_convert/analyze.py
@@ -1,0 +1,256 @@
+"""Step 3: drive Claude over each module to produce annotated .s,
+variables.md, and high-confidence entries in functions.cfg.
+
+Uses the Anthropic API with prompt caching on the system prompt
+(`CLAUDE.md`) + the accumulating `variables.md`, so per-module cost
+stays low even across hundreds of modules.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from anthropic import Anthropic
+
+HERE = Path(__file__).resolve().parent
+SYSTEM_PROMPT_PATH = HERE / "CLAUDE.md"
+PROMPT_TEMPLATE_PATH = HERE / "prompts" / "module_analysis.md"
+
+MODEL = "claude-opus-4-7"
+MAX_TOKENS = 16_000
+
+
+@dataclass
+class AnalysisResult:
+    module_index: int
+    annotated_path: Path
+    functions_added: list[dict]
+    globals_added: list[dict]
+    io_writes: list[dict]
+    constants: list[dict]
+    notes: str
+
+
+class Analyzer:
+    def __init__(self, output_dir: Path, *, model: str = MODEL) -> None:
+        self.output_dir = output_dir
+        self.modules_dir = output_dir / "modules"
+        self.annotated_dir = output_dir / "annotated"
+        self.annotated_dir.mkdir(parents=True, exist_ok=True)
+        self.variables_md_path = output_dir / "variables.md"
+        self.functions_cfg_path = output_dir / "functions.cfg"
+        self.progress_path = output_dir / ".progress.json"
+
+        self.client = Anthropic()
+        self.model = model
+        self.system_prompt = SYSTEM_PROMPT_PATH.read_text()
+        self.template = PROMPT_TEMPLATE_PATH.read_text()
+
+        if not self.variables_md_path.exists():
+            self.variables_md_path.write_text(_VARIABLES_TEMPLATE)
+
+    def analyze_all(
+        self,
+        modules: list[dict],
+        *,
+        force: bool = False,
+    ) -> list[AnalysisResult]:
+        progress = self._load_progress()
+        results: list[AnalysisResult] = []
+
+        for mod in modules:
+            idx = mod["index"]
+            if not force and idx in progress["completed"]:
+                continue
+            try:
+                result = self.analyze_one(mod)
+            except Exception as exc:  # noqa: BLE001 — surface + continue
+                progress["errors"][str(idx)] = f"{type(exc).__name__}: {exc}"
+                self._save_progress(progress)
+                raise
+            results.append(result)
+            progress["completed"].append(idx)
+            progress["errors"].pop(str(idx), None)
+            self._save_progress(progress)
+
+        return results
+
+    def analyze_one(self, mod: dict) -> AnalysisResult:
+        module_path = self.modules_dir / mod["path"]
+        source = module_path.read_text()
+        variables_md = self.variables_md_path.read_text()
+
+        user_prompt = self.template.format(
+            module_path=mod["path"],
+            addr_start=mod["addr_start"],
+            addr_end=mod["addr_end"],
+            kind=mod["kind"],
+            line_count=len(source.splitlines()),
+            variables_md=variables_md,
+            module_source=source,
+        )
+
+        message = self.client.messages.create(
+            model=self.model,
+            max_tokens=MAX_TOKENS,
+            system=[
+                {
+                    "type": "text",
+                    "text": self.system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        raw = "".join(
+            block.text for block in message.content if block.type == "text"
+        )
+        parsed = _extract_json(raw)
+
+        annotated_path = self.annotated_dir / mod["path"]
+        annotated_path.write_text(parsed.get("annotated_source", source))
+
+        functions = parsed.get("functions", []) or []
+        globals_ = parsed.get("globals", []) or []
+        io_writes = parsed.get("io_writes", []) or []
+        constants = parsed.get("constants", []) or []
+        notes = parsed.get("notes", "") or ""
+
+        self._append_variables(mod, functions, globals_, io_writes, constants, notes)
+        self._append_functions_cfg(functions)
+
+        return AnalysisResult(
+            module_index=mod["index"],
+            annotated_path=annotated_path,
+            functions_added=functions,
+            globals_added=globals_,
+            io_writes=io_writes,
+            constants=constants,
+            notes=notes,
+        )
+
+    def _append_variables(
+        self,
+        mod: dict,
+        functions: list[dict],
+        globals_: list[dict],
+        io_writes: list[dict],
+        constants: list[dict],
+        notes: str,
+    ) -> None:
+        if not any((functions, globals_, io_writes, constants, notes.strip())):
+            return
+        block = [f"\n## Module `{mod['path']}`  ({mod['addr_start']}–{mod['addr_end']})\n"]
+        if functions:
+            block.append("### Functions")
+            for f in functions:
+                block.append(
+                    f"- **{f.get('name','?')}** @ `{f.get('address','?')}` "
+                    f"({f.get('mode','?')}) — {f.get('summary','')}"
+                )
+                if f.get("args"):
+                    block.append(f"  - args: {f['args']}")
+                if f.get("returns"):
+                    block.append(f"  - returns: {f['returns']}")
+            block.append("")
+        if globals_:
+            block.append("### Globals")
+            for g in globals_:
+                name = g.get("name") or "_"
+                block.append(
+                    f"- `{g.get('address','?')}` **{name}** "
+                    f"({g.get('type','?')}, {g.get('access','?')}) — {g.get('purpose','')}"
+                )
+            block.append("")
+        if io_writes:
+            block.append("### I/O writes")
+            for w in io_writes:
+                block.append(
+                    f"- **{w.get('register','?')}** ← {w.get('value_or_source','?')}"
+                    f" — {w.get('purpose','')}"
+                )
+            block.append("")
+        if constants:
+            block.append("### Constants")
+            for c in constants:
+                block.append(
+                    f"- `{c.get('value','?')}` — {c.get('meaning','')}"
+                    f" _(ctx: {c.get('context','')})_"
+                )
+            block.append("")
+        if notes.strip():
+            block.append("### Notes")
+            block.append(notes.strip())
+            block.append("")
+
+        with self.variables_md_path.open("a") as fh:
+            fh.write("\n".join(block) + "\n")
+
+    def _append_functions_cfg(self, functions: list[dict]) -> None:
+        highs = [f for f in functions if f.get("confidence") == "high" and f.get("name")]
+        if not highs:
+            return
+        existing = set()
+        if self.functions_cfg_path.exists():
+            for line in self.functions_cfg_path.read_text().splitlines():
+                s = line.strip()
+                if not s or s.startswith("#"):
+                    continue
+                parts = s.split()
+                if len(parts) >= 2:
+                    existing.add(parts[1])
+        new_lines = []
+        for f in highs:
+            addr = str(f.get("address", "")).lower()
+            if not addr or addr in existing:
+                continue
+            mode = "thumb_func" if (f.get("mode", "thumb").lower() == "thumb") else "arm_func"
+            new_lines.append(f"{mode} {addr} {f['name']}")
+            existing.add(addr)
+        if new_lines:
+            with self.functions_cfg_path.open("a") as fh:
+                fh.write("\n".join(new_lines) + "\n")
+
+    def _load_progress(self) -> dict:
+        if self.progress_path.exists():
+            return json.loads(self.progress_path.read_text())
+        return {"completed": [], "errors": {}}
+
+    def _save_progress(self, progress: dict) -> None:
+        self.progress_path.write_text(json.dumps(progress, indent=2) + "\n")
+
+
+_JSON_OBJ = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_json(raw: str) -> dict:
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```[a-zA-Z]*\n?", "", raw)
+        raw = re.sub(r"\n?```$", "", raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        m = _JSON_OBJ.search(raw)
+        if not m:
+            raise
+        return json.loads(m.group(0))
+
+
+_VARIABLES_TEMPLATE = """# Variables & Memory Map
+
+Automatically accumulated by the gba_convert analysis pipeline.
+Each module appends a section below. Do not hand-edit the per-module
+sections — if you rename something, update this file's top-level
+glossary and let the re-run overwrite module-level entries.
+
+## Glossary (hand-edited; survives re-runs)
+
+_Put canonical names here. The analyzer reads this file as context for
+every module call, so entries written here become the source of truth._
+
+"""

--- a/tools/gba_convert/analyze.py
+++ b/tools/gba_convert/analyze.py
@@ -57,12 +57,16 @@ class Analyzer:
         modules: list[dict],
         *,
         force: bool = False,
+        skip_data: bool = True,
     ) -> list[AnalysisResult]:
         progress = self._load_progress()
         results: list[AnalysisResult] = []
 
         for mod in modules:
             idx = mod["index"]
+            if skip_data and mod.get("kind") == "data":
+                progress.setdefault("skipped_data", []).append(idx)
+                continue
             if not force and idx in progress["completed"]:
                 continue
             try:

--- a/tools/gba_convert/data
+++ b/tools/gba_convert/data
@@ -1,0 +1,1 @@
+output/c_view

--- a/tools/gba_convert/disassemble.py
+++ b/tools/gba_convert/disassemble.py
@@ -1,0 +1,119 @@
+"""Step 1: disassemble a GBA ROM with Luvdis.
+
+Shells out to `python -m luvdis` using the local Luvdis checkout at
+`../../luvdis/`. No pip install needed.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+LUVDIS_DIR = REPO_ROOT / "luvdis"
+
+
+@dataclass
+class DisasmResult:
+    rom_path: Path
+    rom_hash: str
+    rom_info: str
+    asm_path: Path
+    config_out_path: Path
+
+
+def _sha1(path: Path) -> str:
+    h = hashlib.sha1()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _luvdis_env() -> dict:
+    """Ensure local Luvdis is importable even without `pip install -e`."""
+    env = os.environ.copy()
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        f"{LUVDIS_DIR}{os.pathsep}{existing}" if existing else str(LUVDIS_DIR)
+    )
+    return env
+
+
+def _run_luvdis(args: list[str], capture: bool = False) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, "-m", "luvdis", *args]
+    proc = subprocess.run(
+        cmd,
+        env=_luvdis_env(),
+        check=False,
+        capture_output=capture,
+        text=True,
+    )
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-10:]
+        raise RuntimeError(
+            f"luvdis {args[0]} failed (exit {proc.returncode}):\n  "
+            + "\n  ".join(tail)
+        )
+    return proc
+
+
+def disassemble(
+    rom_path: Path,
+    output_dir: Path,
+    *,
+    default_mode: str = "BYTE",
+    start: int | None = None,
+    stop: int | None = None,
+    seed_config: Path | None = None,
+) -> DisasmResult:
+    rom_path = Path(rom_path).resolve()
+    if not rom_path.is_file():
+        raise FileNotFoundError(f"ROM not found: {rom_path}")
+    if not LUVDIS_DIR.is_dir():
+        raise FileNotFoundError(
+            f"Luvdis checkout missing at {LUVDIS_DIR}; clone it there first."
+        )
+
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    asm_path = output_dir / "rom.s"
+    config_out = output_dir / "functions.cfg"
+    info_path = output_dir / "rom.info.txt"
+
+    rom_hash = _sha1(rom_path)
+
+    info = _run_luvdis(["info", str(rom_path)], capture=True)
+    info_text = (info.stdout or "") + (info.stderr or "")
+    info_path.write_text(f"sha1: {rom_hash}\n\n{info_text}")
+
+    args = [
+        "disasm",
+        str(rom_path),
+        "-o",
+        str(asm_path),
+        "-co",
+        str(config_out),
+        "--default-mode",
+        default_mode,
+    ]
+    if start is not None:
+        args += ["--start", hex(start)]
+    if stop is not None:
+        args += ["--stop", hex(stop)]
+    if seed_config is not None and seed_config.is_file():
+        args += ["-c", str(seed_config)]
+
+    _run_luvdis(args)
+
+    return DisasmResult(
+        rom_path=rom_path,
+        rom_hash=rom_hash,
+        rom_info=info_text.strip(),
+        asm_path=asm_path,
+        config_out_path=config_out,
+    )

--- a/tools/gba_convert/disassemble.py
+++ b/tools/gba_convert/disassemble.py
@@ -37,10 +37,13 @@ def _sha1(path: Path) -> str:
 def _luvdis_env() -> dict:
     """Ensure local Luvdis is importable even without `pip install -e`."""
     env = os.environ.copy()
+    # Try using the installed package first, fall back to local directory
     existing = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = (
-        f"{LUVDIS_DIR}{os.pathsep}{existing}" if existing else str(LUVDIS_DIR)
-    )
+    # Add local luvdis dir at the end so installed package takes precedence
+    if existing:
+        env["PYTHONPATH"] = f"{existing}{os.pathsep}{LUVDIS_DIR}"
+    else:
+        env["PYTHONPATH"] = str(LUVDIS_DIR)
     return env
 
 

--- a/tools/gba_convert/edit.py
+++ b/tools/gba_convert/edit.py
@@ -1,0 +1,276 @@
+"""Step 4.5: apply a natural-language edit to a c_view module.
+
+Workflow:
+    python edit.py "bump max HP from 100 to 999"
+
+  Stage 1: Claude reads variables.md + the list of c_view modules and
+           picks the most likely target file.
+  Stage 2: Claude rewrites that module to carry out the instruction.
+  Stage 3: We try compiling the result with arm-none-eabi-gcc. On
+           failure, the stderr is fed back to Claude and Stage 2 repeats
+           (up to MAX_RETRIES times).
+  Stage 4: On success, the new source lands in output/edited/<name>.c.
+
+After this, run:
+    python recompile.py   # splice compiled bytes into recompiled/*.s
+    python rebuild.py     # assemble + link + objcopy → rebuilt.gba
+
+See PROCESS.md §11b for the surgical-splice model.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+from anthropic import Anthropic
+
+from recompile import check_toolchain, compile_module
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = HERE / "output"
+SYSTEM_PROMPT_PATH = HERE / "CLAUDE.md"
+TARGET_PROMPT_PATH = HERE / "prompts" / "edit_target.md"
+APPLY_PROMPT_PATH = HERE / "prompts" / "edit_apply.md"
+
+MODEL = "claude-opus-4-7"
+MAX_TOKENS = 16_000
+MAX_RETRIES = 3
+
+
+@dataclass
+class EditResult:
+    module_name: str
+    c_path: Path
+    notes: str
+    attempts: int
+
+
+class Editor:
+    def __init__(self, output_dir: Path, *, model: str = MODEL) -> None:
+        self.output_dir = output_dir
+        self.c_view_dir = output_dir / "c_view"
+        self.edited_dir = output_dir / "edited"
+        vars_path = output_dir / "variables.md"
+        self.variables_md = vars_path.read_text() if vars_path.is_file() else "(variables.md not found)"
+
+        self.client = Anthropic()
+        self.model = model
+        self.system_prompt = SYSTEM_PROMPT_PATH.read_text()
+        self.target_template = TARGET_PROMPT_PATH.read_text()
+        self.apply_template = APPLY_PROMPT_PATH.read_text()
+
+    def find_target(self, instruction: str) -> str:
+        modules = sorted(p.name for p in self.c_view_dir.glob("mod_*.c"))
+        if not modules:
+            raise click.ClickException(f"no c_view modules found in {self.c_view_dir}")
+        prompt = self.target_template.format(
+            instruction=instruction,
+            variables_md=self.variables_md,
+            module_list="\n".join(f"- {m}" for m in modules),
+        )
+        raw = self._call(prompt)
+        parsed = _extract_json(raw)
+        candidates = parsed.get("candidates") or []
+        reasoning = parsed.get("reasoning", "(no reasoning)")
+        if not candidates:
+            raise click.ClickException(
+                f"Claude found no candidate module. Reasoning: {reasoning}"
+            )
+        top = candidates[0]
+        if top not in modules:
+            raise click.ClickException(
+                f"Claude picked unknown module {top!r}. Reasoning: {reasoning}"
+            )
+        click.echo(f"  reasoning: {reasoning}")
+        if len(candidates) > 1:
+            click.echo(f"  also considered: {', '.join(candidates[1:])}")
+        return top
+
+    def apply_edit(self, module_name: str, instruction: str) -> EditResult:
+        baseline = (self.c_view_dir / module_name).read_text()
+        self.edited_dir.mkdir(parents=True, exist_ok=True)
+        out_path = self.edited_dir / module_name
+        obj_path = out_path.with_suffix(".o.test")
+
+        retry_context = ""
+        last_stderr = ""
+        last_source = ""
+
+        for attempt in range(1, MAX_RETRIES + 1):
+            click.echo(f"  attempt {attempt}/{MAX_RETRIES}...")
+            prompt = self.apply_template.format(
+                instruction=instruction,
+                module_name=module_name,
+                source=baseline,
+                variables_md=self.variables_md,
+                retry_context=retry_context,
+            )
+            raw = self._call(prompt)
+            parsed = _extract_json(raw)
+            new_source = parsed.get("c_source", "") or ""
+            notes = parsed.get("notes", "") or ""
+
+            if not new_source.strip():
+                raise click.ClickException(
+                    f"Claude returned empty c_source on attempt {attempt}"
+                )
+
+            out_path.write_text(new_source)
+            last_source = new_source
+
+            try:
+                compile_module(out_path, obj_path, self.c_view_dir)
+                obj_path.unlink(missing_ok=True)
+                click.secho(f"  ✓ compiled cleanly on attempt {attempt}", fg="green")
+                return EditResult(
+                    module_name=module_name,
+                    c_path=out_path,
+                    notes=notes,
+                    attempts=attempt,
+                )
+            except subprocess.CalledProcessError as exc:
+                last_stderr = (exc.stderr or "").strip() or "(no stderr)"
+                click.secho(f"  ✗ gcc rejected attempt {attempt}", fg="yellow")
+                for line in last_stderr.splitlines()[:8]:
+                    click.echo(f"    {line}")
+                if attempt < MAX_RETRIES:
+                    retry_context = _retry_block(last_source, last_stderr)
+
+        out_path.write_text(last_source)
+        raise click.ClickException(
+            f"Edit failed after {MAX_RETRIES} attempts. "
+            f"Last attempt saved at {out_path}. Last stderr:\n{last_stderr}"
+        )
+
+    def _call(self, prompt: str) -> str:
+        message = self.client.messages.create(
+            model=self.model,
+            max_tokens=MAX_TOKENS,
+            system=[{
+                "type": "text",
+                "text": self.system_prompt,
+                "cache_control": {"type": "ephemeral"},
+            }],
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return "".join(b.text for b in message.content if b.type == "text")
+
+
+def _retry_block(prev_source: str, stderr: str) -> str:
+    return (
+        "\n\n---\n\n"
+        "## Your previous attempt failed to compile\n\n"
+        "### Your previous output\n\n"
+        "```c\n"
+        f"{prev_source}\n"
+        "```\n\n"
+        "### gcc stderr\n\n"
+        "```\n"
+        f"{stderr}\n"
+        "```\n\n"
+        "Fix the error(s) and return corrected source in the same JSON "
+        "format. Do NOT relax the hard constraints — signatures stay, "
+        "`#include \"gba.h\"` stays, no libc."
+    )
+
+
+_JSON_OBJ = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_json(raw: str) -> dict:
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```[a-zA-Z]*\n?", "", raw)
+        raw = re.sub(r"\n?```$", "", raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        m = _JSON_OBJ.search(raw)
+        if not m:
+            raise
+        return json.loads(m.group(0))
+
+
+@click.command()
+@click.argument("instruction")
+@click.option("--output", type=click.Path(path_type=Path), default=DEFAULT_OUTPUT,
+              show_default=True,
+              help="Output directory created by pipeline.py.")
+@click.option("--module", "module_override", default=None,
+              help="Skip Stage 1. Edit this module directly "
+                   "(e.g. mod_0017_080A1B30.c or just mod_0017_080A1B30).")
+@click.option("--model", default=MODEL, show_default=True,
+              help="Anthropic model ID.")
+def main(
+    instruction: str,
+    output: Path,
+    module_override: str | None,
+    model: str,
+) -> None:
+    """Apply a natural-language edit to one c_view module."""
+    output = output.resolve()
+    c_view = output / "c_view"
+
+    if not c_view.is_dir():
+        click.secho(
+            f"  {c_view} missing — run `python pipeline.py ROM` first "
+            f"(through step 4).",
+            fg="red",
+        )
+        sys.exit(2)
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        click.secho("  ANTHROPIC_API_KEY not set. Export it and re-run.", fg="red")
+        sys.exit(2)
+
+    click.secho("== toolchain check ==", fg="cyan", bold=True)
+    tc = check_toolchain()
+    for tool, path in tc.found.items():
+        click.echo(f"  ✓ {tool}: {path}")
+    for tool in tc.missing:
+        click.secho(f"  ✗ {tool}: MISSING", fg="red")
+    if not tc.ok:
+        click.secho(
+            "  Install the ARM toolchain "
+            "(macOS: `brew install --cask gcc-arm-embedded`).",
+            fg="red",
+        )
+        sys.exit(2)
+
+    editor = Editor(output, model=model)
+
+    if module_override:
+        target = module_override if module_override.endswith(".c") else f"{module_override}.c"
+        if not (c_view / target).is_file():
+            click.secho(f"  {c_view / target} not found.", fg="red")
+            sys.exit(2)
+        click.echo(f"  using explicit target: {target}")
+    else:
+        click.secho("== stage 1: pick target module ==", fg="cyan", bold=True)
+        target = editor.find_target(instruction)
+        click.echo(f"  target: {target}")
+
+    click.secho("== stage 2: apply edit + compile loop ==", fg="cyan", bold=True)
+    result = editor.apply_edit(target, instruction)
+
+    click.secho(
+        f"\n  ✓ wrote {result.c_path} (attempts: {result.attempts})",
+        fg="green",
+    )
+    if result.notes:
+        click.echo(f"  notes: {result.notes}")
+    click.echo(
+        "\n  Next:\n"
+        "    python recompile.py   # splice compiled bytes into recompiled/*.s\n"
+        "    python rebuild.py     # assemble → rebuilt.gba"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gba_convert/gemini_adapter.py
+++ b/tools/gba_convert/gemini_adapter.py
@@ -1,0 +1,92 @@
+"""Minimal Gemini adapter to present a compatible interface to
+`translate_to_c.py` which expects an `Anthropic()`-like client.
+
+Uses the new `google-genai` SDK (pip install google-genai).
+"""
+from __future__ import annotations
+
+import os
+
+try:
+    from google import genai
+except Exception as exc:
+    raise RuntimeError(
+        "Install the Gemini SDK: pip install google-genai"
+    ) from exc
+
+# Default model when the caller passes a non-Gemini name (e.g. 'claude-opus-4-7')
+_DEFAULT_MODEL = "gemini-2.0-flash-lite"
+
+
+class _Block:
+    def __init__(self, t: str, text: str) -> None:
+        self.type = t
+        self.text = text
+
+
+class _Resp:
+    def __init__(self, blocks: list[_Block]) -> None:
+        self.content = blocks
+
+
+def _resolve_model(raw: str | None) -> str:
+    """Pick a Gemini model name from env override, caller arg, or default."""
+    env = os.environ.get("GEMINI_MODEL")
+    if env:
+        return env
+    if isinstance(raw, str) and "gemini" in raw.lower():
+        return raw
+    return _DEFAULT_MODEL
+
+
+class GeminiClient:
+    """Drop-in replacement for the Anthropic client used by translate_to_c."""
+
+    def __init__(self) -> None:
+        api_key = os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            raise RuntimeError("GEMINI_API_KEY not set")
+        self._client = genai.Client(api_key=api_key)
+        self.messages = self._Messages(self._client)
+
+    class _Messages:
+        def __init__(self, client):
+            self._client = client
+
+        def create(self, model, max_tokens, system, messages):
+            # Assemble system instruction
+            sys_texts = []
+            for s in (system or []):
+                if isinstance(s, dict):
+                    sys_texts.append(s.get("text", ""))
+                else:
+                    sys_texts.append(str(s))
+            sys_text = "\n".join(sys_texts)
+
+            # Assemble user content
+            user_text = "\n\n".join(
+                m.get("content", "") for m in messages
+            )
+
+            model_name = _resolve_model(model)
+            max_out = int(
+                os.environ.get("GEMINI_MAX_TOKENS", max_tokens or 8192)
+            )
+
+            resp = self._client.models.generate_content(
+                model=model_name,
+                contents=user_text,
+                config={
+                    "system_instruction": sys_text,
+                    "max_output_tokens": max_out,
+                    "temperature": 0.0,
+                },
+            )
+
+            # Extract text
+            try:
+                text = resp.text
+            except Exception:
+                text = str(resp)
+
+            return _Resp([_Block("text", text or "")])

--- a/tools/gba_convert/iterative_loop.py
+++ b/tools/gba_convert/iterative_loop.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+"""Iterative decompile/compile/compare loop for a single module.
+
+Usage examples:
+  # dry-run (no LLM, no toolchain)
+  python iterative_loop.py output/modules/mod_0000_08000000.s --mode dryrun --iterations 2
+
+  # full (requires ANTHROPIC_API_KEY and arm-none-eabi toolchain)
+  python iterative_loop.py output/modules/mod_0000_08000000.s --mode llm --compile
+
+The script attempts to use the repository's `translate_to_c.py` and
+`recompile.py` when available. When dependencies are missing it falls
+back to a lightweight pseudo-decompile and prints diagnostics.
+"""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Tuple, Optional
+import subprocess
+import shutil
+import struct
+
+import click
+
+
+def parse_module_bytes(s_path: Path) -> bytes:
+    """Extract raw bytes from `.byte`, `.hword`/`.2byte`, and `.word` directives.
+
+    Falls back to scanning for explicit 0x.. tokens if directives are sparse.
+    """
+    data = bytearray()
+    text = s_path.read_text()
+    lines = text.splitlines()
+    for raw in lines:
+        line = raw.split("@", 1)[0].strip()
+        if not line:
+            continue
+        # .byte / .2byte / .4byte / .hword / .word / .ascii / .asciz / .space
+        m = re.match(r"^\s*\.(byte|db)\s+(.*)$", line, flags=re.IGNORECASE)
+        if m:
+            ops = m.group(2)
+            for token in re.split(r",\s*", ops):
+                if not token:
+                    continue
+                token = token.strip()
+                if token.startswith('"') or token.startswith("'"):
+                    try:
+                        s = ast.literal_eval(token)
+                        data += s.encode('latin1') if isinstance(s, str) else s
+                    except Exception:
+                        continue
+                else:
+                    try:
+                        v = int(token, 0)
+                    except Exception:
+                        continue
+                    data.append(v & 0xFF)
+            continue
+
+        m2 = re.match(r"^\s*\.(2byte|hword|short|half)\s+(.*)$", line, flags=re.IGNORECASE)
+        if m2:
+            ops = m2.group(2)
+            for token in re.split(r",\s*", ops):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    v = int(token, 0)
+                except Exception:
+                    continue
+                data += int(v).to_bytes(2, "little", signed=False)
+            continue
+
+        m4 = re.match(r"^\s*\.(4byte|word|long|int)\s+(.*)$", line, flags=re.IGNORECASE)
+        if m4:
+            ops = m4.group(2)
+            for token in re.split(r",\s*", ops):
+                token = token.strip()
+                if not token:
+                    continue
+                try:
+                    v = int(token, 0)
+                except Exception:
+                    continue
+                data += int(v).to_bytes(4, "little", signed=False)
+            continue
+
+        mspace = re.match(r"^\s*\.(space|skip|zero)\s+(\S+)", line, flags=re.IGNORECASE)
+        if mspace:
+            try:
+                n = int(mspace.group(2), 0)
+            except Exception:
+                n = 0
+            data += b"\x00" * n
+            continue
+
+    # fallback: scan for standalone 0xHH tokens if we collected nothing
+    if not data:
+        for m in re.finditer(r"0x([0-9A-Fa-f]{2})", text):
+            data.append(int(m.group(1), 16))
+
+    return bytes(data)
+
+
+def pseudo_decompile(module_path: Path, out_c: Path) -> None:
+    """Write a minimal, readable C skeleton that documents the bytes.
+
+    This is a fallback for environments without an LLM. The produced C
+    is not a faithful decompile but gives a human-editable starting
+    point for iterative refinement.
+    """
+    addr_match = re.search(r"mod_\d+_([0-9A-Fa-f]+)\.s$", module_path.name)
+    addr = addr_match.group(1).lower() if addr_match else "unknown"
+    func_name = f"sub_{addr}"
+
+    orig = parse_module_bytes(module_path)
+    # show up to first 256 bytes as comment
+    preview = " ".join(f"{b:02X}" for b in orig[:256])
+
+    header = """
+#include <stdint.h>
+#include <stddef.h>
+#include "gba.h"
+
+/* Pseudo-decompiled from %s */
+/* original bytes (first 256): %s */
+""" % (module_path.name, preview)
+
+    body = (
+        "\nvoid " + func_name + "(void) {\n"
+        "    // TODO: replace this skeleton with real C\n"
+        "    // original bytes length: " + str(len(orig)) + "\n"
+        "    return;\n"
+        "}\n"
+    )
+
+    out_c.parent.mkdir(parents=True, exist_ok=True)
+    out_c.write_text(header + body)
+
+
+def compare_bytes(orig: bytes, new: bytes, max_lines: int = 16) -> Tuple[int, str]:
+    """Return (diff_count, human_readable_sample)."""
+    n = min(len(orig), len(new))
+    diffs = []
+    diff_count = 0
+    for i in range(n):
+        if orig[i] != new[i]:
+            diff_count += 1
+            if len(diffs) < max_lines:
+                diffs.append(f"@{i:06X}: orig={orig[i]:02X} new={new[i]:02X}")
+    # account for length differences
+    if len(orig) != len(new):
+        diff_count += abs(len(orig) - len(new))
+    sample = "\n".join(diffs)
+    return diff_count, sample
+
+
+def _find_ghidra_analyze_headless() -> Optional[Path]:
+    """Locate an analyzeHeadless executable from GHIDRA_HOME, workspace install, or PATH."""
+    gh_home = os.environ.get("GHIDRA_HOME")
+    if gh_home:
+        p = Path(gh_home) / "support" / "analyzeHeadless"
+        if p.exists():
+            return p
+    # try workspace ghidra_install
+    inst_root = Path.cwd().parent.parent / "ghidra_install"
+    if not inst_root.exists():
+        inst_root = Path("/workspaces/codespaces-blank/ghidra_install")
+    if inst_root.exists():
+        for d in inst_root.iterdir():
+            if d.is_dir() and d.name.lower().startswith("ghidra"):
+                p = d / "support" / "analyzeHeadless"
+                if p.exists():
+                    return p
+    p = shutil.which("analyzeHeadless")
+    if p:
+        return Path(p)
+    return None
+
+
+def ghidra_decompile(mod_entry: dict, out_c_path: Path, rom_path: Optional[Path], project_root: Path) -> bool:
+    """Run Ghidra headless to decompile functions in the module address range.
+
+    Returns True if `out_c_path` was produced.
+    """
+    analyze = _find_ghidra_analyze_headless()
+    if analyze is None:
+        click.secho("Ghidra analyzeHeadless not found; set GHIDRA_HOME or install under ghidra_install", fg="red")
+        return False
+
+    start = mod_entry.get("addr_start")
+    end = mod_entry.get("addr_end")
+    if not start or not end:
+        click.secho("Module entry missing addr_start/addr_end", fg="red")
+        return False
+
+    # determine ROM to import (may be unused if we instead build an ELF from the module)
+    rom_file = None
+    if rom_path:
+        rom_file = Path(rom_path)
+        if not rom_file.exists():
+            click.secho(f"Provided ROM not found: {rom_file}", fg="yellow")
+            rom_file = None
+    if rom_file is None:
+        candidates = list(Path.cwd().glob("**/*.gba"))
+        if candidates:
+            rom_file = candidates[0]
+
+    project_root = project_root.resolve()
+    proj_dir = project_root / "ghidra_project"
+    if proj_dir.exists():
+        shutil.rmtree(proj_dir)
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    project_name = "iter_ghidra"
+
+    # ensure script paths are absolute
+    script_path = project_root / "ghidra_decompile.py"
+    script_contents = r"""# ghidra_decompile.py
+from ghidra.app.decompiler import DecompInterface
+from ghidra.util.task import ConsoleTaskMonitor
+import sys
+
+def to_addr_obj(a):
+    try:
+        return toAddr(a)
+    except:
+        return toAddr(int(a, 16))
+
+if len(sys.argv) < 4:
+    print('Usage: ghidra_decompile.py start_addr end_addr out_path')
+else:
+    start = sys.argv[1]
+    end = sys.argv[2]
+    out_path = sys.argv[3]
+    di = DecompInterface()
+    di.openProgram(currentProgram)
+    fm = currentProgram.getFunctionManager()
+    out_lines = []
+    s_addr = to_addr_obj(start)
+    e_addr = to_addr_obj(end)
+    for func in fm.getFunctions(True):
+        entry = func.getEntryPoint()
+        if entry.compareTo(s_addr) >= 0 and entry.compareTo(e_addr) <= 0:
+            res = di.decompileFunction(func, 60, ConsoleTaskMonitor())
+            if res.decompileCompleted():
+                cfunc = res.getDecompiledFunction()
+                if cfunc:
+                    out_lines.append('// Function: %s at %s\n' % (func.getName(), entry))
+                    out_lines.append(str(cfunc.getC()))
+                    out_lines.append('\n\n')
+    f = open(out_path, 'w')
+    f.write('\n'.join(out_lines))
+    f.close()
+"""
+    script_path.write_text(script_contents)
+
+    # Also write a Java GhidraScript fallback (does not require PyGhidra)
+    script_java_path = project_root / "ghidra_decompile.java"
+    script_java = r"""import java.io.*;
+import ghidra.app.decompiler.*;
+import ghidra.util.task.ConsoleTaskMonitor;
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.address.Address;
+
+public class ghidra_decompile extends GhidraScript {
+    @Override
+    public void run() throws Exception {
+        String[] args = getScriptArgs();
+        if (args == null || args.length < 3) {
+            println("Usage: ghidra_decompile start_addr end_addr out_path");
+            return;
+        }
+        String start = args[0];
+        String end = args[1];
+        String outPath = args[2];
+        Address s = toAddr(start);
+        Address e = toAddr(end);
+        DecompInterface di = new DecompInterface();
+        di.openProgram(currentProgram);
+        FunctionManager fm = currentProgram.getFunctionManager();
+        PrintWriter out = new PrintWriter(new FileWriter(outPath));
+        try {
+            for (Function func : fm.getFunctions(true)) {
+                Address entry = func.getEntryPoint();
+                if (entry.compareTo(s) >= 0 && entry.compareTo(e) <= 0) {
+                    DecompileResults res = di.decompileFunction(func, 60, new ConsoleTaskMonitor());
+                    if (res.decompileCompleted()) {
+                        out.println("// Function: " + func.getName() + " at " + entry);
+                        if (res.getDecompiledFunction() != null) {
+                            out.println(res.getDecompiledFunction().getC());
+                        }
+                        out.println();
+                    }
+                }
+            }
+        } finally {
+            out.close();
+        }
+    }
+}
+"""
+    script_java_path.write_text(script_java)
+
+    # Prefer importing a small ELF built from the module bytes when available
+    elf_candidate = None
+    try:
+        # try to locate the module file under output/modules
+        mod_path = project_root / "modules" / mod_entry.get("path", "")
+        if mod_path.exists():
+            # create an ELF file from the module bytes
+            elf_candidate = project_root / (mod_path.stem + ".elf")
+            payload = parse_module_bytes(mod_path)
+            if payload:
+                # build a minimal ELF32 (ARM) with one PT_LOAD at p_vaddr = addr_start
+                load_addr = int(start, 0)
+                e_ident = bytearray(16)
+                e_ident[0:4] = b"\x7fELF"
+                e_ident[4] = 1  # ELFCLASS32
+                e_ident[5] = 1  # ELFDATA2LSB
+                e_ident[6] = 1  # EV_CURRENT
+                # rest zero
+                e_type = 2
+                e_machine = 0x28  # EM_ARM
+                e_version = 1
+                e_entry = load_addr
+                e_phoff = 52
+                e_shoff = 0
+                e_flags = 0
+                e_ehsize = 52
+                e_phentsize = 32
+                e_phnum = 1
+                e_shentsize = 0
+                e_shnum = 0
+                e_shstrndx = 0
+                header = bytes(e_ident) + struct.pack('<HHIIIIIHHHHHH', e_type, e_machine, e_version, e_entry, e_phoff, e_shoff, e_flags, e_ehsize, e_phentsize, e_phnum, e_shentsize, e_shnum, e_shstrndx)
+                p_offset = e_phoff + e_phentsize * e_phnum
+                p_vaddr = load_addr
+                p_paddr = p_vaddr
+                p_filesz = len(payload)
+                p_memsz = p_filesz
+                p_flags = 5  # PF_R | PF_X
+                p_align = 0x1000
+                phdr = struct.pack('<IIIIIIII', 1, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_flags, p_align)
+                with open(elf_candidate, 'wb') as f:
+                    f.write(header)
+                    f.write(phdr)
+                    # ensure we are at p_offset
+                    cur = f.tell()
+                    if cur < p_offset:
+                        f.write(b'\x00' * (p_offset - cur))
+                    f.write(payload)
+    except Exception:
+        elf_candidate = None
+
+    if elf_candidate and elf_candidate.exists():
+        input_file = elf_candidate.resolve()
+    elif rom_file is not None:
+        input_file = Path(rom_file).resolve()
+    else:
+        click.secho("No suitable input file found for Ghidra import", fg="red")
+        return False
+
+    # prefer Java script (works headless without PyGhidra); pass absolute script path
+    script_to_use = script_java_path.resolve()
+    cmd = [
+        str(analyze),
+        str(proj_dir),
+        project_name,
+        "-import",
+        str(input_file),
+        "-scriptPath",
+        str(project_root.resolve()),
+        "-postScript",
+        script_to_use.name,
+        start,
+        end,
+        str(out_c_path),
+        "-overwrite",
+    ]
+    click.echo("Running Ghidra headless: " + " ".join(cmd[:4]) + " ...")
+    try:
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as exc:
+        click.secho(f"Ghidra analyzeHeadless failed: {exc}", fg="red")
+        return False
+    if out_c_path.exists():
+        click.echo(f"Ghidra produced: {out_c_path}")
+        return True
+    click.secho("Ghidra finished but output file not produced", fg="yellow")
+    return False
+
+
+@click.command()
+@click.argument("module", type=click.Path(exists=True, path_type=Path))
+@click.option("--iterations", type=int, default=3, show_default=True,
+              help="Maximum iterations")
+@click.option("--mode", type=click.Choice(["dryrun", "llm", "ghidra", "ghidra_llm"]), default="dryrun",
+              help="Decompile mode; `llm`/`ghidra_llm` require GEMINI_API_KEY or ANTHROPIC_API_KEY")
+@click.option("--rom", type=click.Path(exists=False, path_type=Path), default=None,
+              help="Optional path to the original ROM to analyze with Ghidra")
+@click.option("--compile/--no-compile", default=False,
+              help="Attempt to compile generated C (requires arm toolchain)")
+def main(module: Path, iterations: int, mode: str, rom: Optional[Path], compile: bool) -> None:
+    output_root = module.parent.parent  # e.g. .../output
+    c_view_dir = output_root / "c_view"
+    run_dir = output_root / "iterative_runs"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"module: {module}")
+    orig_bytes = parse_module_bytes(module)
+    click.echo(f"original bytes extracted: {len(orig_bytes)} B")
+
+    # optional imports that require toolchain/LLM
+    recompile_mod = None
+    translator_mod = None
+    if compile:
+        try:
+            import recompile as recompile_mod
+        except Exception as exc:
+            click.secho("Toolchain helper import failed: recompile.py not usable", fg="yellow")
+            recompile_mod = None
+
+    if mode in ("llm", "ghidra_llm"):
+        if not (os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("GEMINI_API_KEY")):
+            click.secho("No LLM API key found — set ANTHROPIC_API_KEY or GEMINI_API_KEY", fg="red")
+            return
+        try:
+            from translate_to_c import CTranslator
+            translator_mod = CTranslator(output_root)
+        except Exception as exc:
+            click.secho(f"Failed to construct CTranslator: {exc}", fg="red")
+            translator_mod = None
+
+    last_c = None
+    for it in range(1, iterations + 1):
+        click.echo(f"\n--- iteration {it}/{iterations} ---")
+
+        # 1) Decompile
+        if mode == "llm" and translator_mod is not None:
+            click.echo("Decompiling with LLM (translate_to_c)")
+            # find module metadata in _index.json
+            idx_path = output_root / "modules" / "_index.json"
+            if not idx_path.exists():
+                click.secho("modules/_index.json missing — run pipeline split first", fg="red")
+                return
+            mods = json.loads(idx_path.read_text())
+            mod_entry = next((m for m in mods if m.get("path") == module.name), None)
+            if not mod_entry:
+                click.secho("module not found in _index.json", fg="red")
+                return
+            try:
+                res = translator_mod.translate_one(mod_entry, module)
+                c_path = res.c_path
+                click.echo(f"LLM produced: {c_path}")
+            except Exception as exc:
+                click.secho(f"LLM translation failed: {exc}", fg="red")
+                return
+        elif mode == "ghidra_llm" and translator_mod is not None:
+            # --- Ghidra first, then LLM refinement ---
+            idx_path = output_root / "modules" / "_index.json"
+            if not idx_path.exists():
+                click.secho("modules/_index.json missing — run pipeline split first", fg="red")
+                return
+            mods = json.loads(idx_path.read_text())
+            mod_entry = next((m for m in mods if m.get("path") == module.name), None)
+            if not mod_entry:
+                click.secho("module not found in _index.json", fg="red")
+                return
+            ghidra_tmp = run_dir / (module.stem + "_ghidra_raw.c")
+            click.echo("Running Ghidra headless decompile...")
+            ghidra_ok = ghidra_decompile(mod_entry, ghidra_tmp, rom, output_root)
+            ghidra_hint = ""
+            if ghidra_ok and ghidra_tmp.exists():
+                ghidra_hint = ghidra_tmp.read_text()
+                click.echo(f"Ghidra raw output: {len(ghidra_hint)} chars")
+            else:
+                click.secho("Ghidra produced no output; LLM will decompile from ASM alone", fg="yellow")
+            click.echo("Refining with LLM (translate_to_c + Ghidra hint)...")
+            try:
+                res = translator_mod.translate_one(mod_entry, module, ghidra_hint=ghidra_hint)
+                c_path = res.c_path
+                click.echo(f"LLM produced: {c_path}")
+            except Exception as exc:
+                click.secho(f"LLM translation failed: {exc}", fg="red")
+                return
+        elif mode == "ghidra":
+            # attempt headless Ghidra decompile for the module
+            idx_path = output_root / "modules" / "_index.json"
+            if not idx_path.exists():
+                click.secho("modules/_index.json missing — run pipeline split first", fg="red")
+                return
+            mods = json.loads(idx_path.read_text())
+            mod_entry = next((m for m in mods if m.get("path") == module.name), None)
+            if not mod_entry:
+                click.secho("module not found in _index.json", fg="red")
+                return
+            c_path = run_dir / (module.stem + ".c")
+            click.echo("Attempting Ghidra headless decompile (this may take a while)")
+            ok = ghidra_decompile(mod_entry, c_path, rom, output_root)
+            if not ok:
+                click.secho("Ghidra decompile failed or produced nothing; falling back to pseudo-decompile", fg="yellow")
+                if not c_path.exists():
+                    pseudo_decompile(module, c_path)
+            else:
+                click.echo(f"Using Ghidra output: {c_path}")
+        else:
+            # dryrun or fallback
+            c_path = run_dir / (module.stem + ".c")
+            if not c_path.exists():
+                click.echo("Writing pseudo-C fallback")
+                pseudo_decompile(module, c_path)
+            else:
+                click.echo(f"Using existing C: {c_path}")
+
+        last_c = c_path
+
+        # 2) Compile (optional)
+        compiled_bytes = b""
+        if compile:
+            if recompile_mod is None:
+                click.secho("Compile requested but recompile helper unavailable", fg="yellow")
+            else:
+                tc = recompile_mod.check_toolchain()
+                if not tc.ok:
+                    click.secho(f"Missing toolchain: {tc.missing}", fg="red")
+                else:
+                    click.echo("Compiling C to binary (.text / .rodata)")
+                    build_dir = run_dir / "build"
+                    build_dir.mkdir(parents=True, exist_ok=True)
+                    obj = build_dir / (c_path.stem + ".o")
+                    bin_out = build_dir / (c_path.stem + ".bin")
+                    # also ensure raw .bin source files exist as actual binary
+                    # (LLM may emit .incbin references)
+                    raw_bin_src = c_view_dir / (c_path.stem + ".bin")
+                    if not raw_bin_src.exists():
+                        raw_bytes_src = parse_module_bytes(module)
+                        if raw_bytes_src:
+                            raw_bin_src.write_bytes(raw_bytes_src)
+                            click.echo(f"  wrote raw binary include: {raw_bin_src}")
+                    try:
+                        recompile_mod.compile_module(c_path, obj, c_view_dir)
+                        recompile_mod.extract_text_bin(obj, bin_out)
+                        compiled_bytes = bin_out.read_bytes()
+                        if not compiled_bytes:
+                            # fall back to .rodata (data-only modules emit here)
+                            rodata_out = build_dir / (c_path.stem + "_rodata.bin")
+                            subprocess.run([
+                                "arm-none-eabi-objcopy", "-O", "binary",
+                                "--only-section=.rodata",
+                                str(obj), str(rodata_out),
+                            ], check=True, capture_output=True)
+                            if rodata_out.exists() and rodata_out.stat().st_size > 0:
+                                compiled_bytes = rodata_out.read_bytes()
+                                click.echo(f"compiled .rodata (data module): {len(compiled_bytes)} B")
+                            else:
+                                click.secho("compiled .text and .rodata are both 0 bytes — no code or data", fg="yellow")
+                        else:
+                            click.echo(f"compiled .text: {len(compiled_bytes)} B")
+                    except subprocess.CalledProcessError as exc:
+                        click.secho(f"Compilation failed (exit {exc.returncode}):", fg="red")
+                        if exc.stderr:
+                            click.echo(exc.stderr[:2000])
+                        if exc.stdout:
+                            click.echo(exc.stdout[:500])
+                    except Exception as exc:
+                        click.secho(f"Compilation failed: {exc}", fg="red")
+
+        # 3) Compare
+        if compiled_bytes:
+            diff_count, sample = compare_bytes(orig_bytes, compiled_bytes)
+            if diff_count == 0:
+                click.secho("Compiled bytes match original — converged.", fg="green")
+                return
+            else:
+                click.secho(f"Differences: {diff_count} byte(s)", fg="yellow")
+                if sample:
+                    click.echo("Sample diffs:\n" + sample)
+        else:
+            click.secho("No compiled bytes to compare (compile skipped or failed)", fg="yellow")
+
+        # 4) If LLM mode, provide the diff to the next decompile pass.
+        if mode in ("llm", "ghidra_llm") and translator_mod is not None and compiled_bytes:
+            click.echo("Feeding diff back to LLM for next pass (not implemented: pass diff via annotated file)")
+            # Implementation note: to give feedback to the translator we would
+            # modify the annotated .s to include the diff or extend the prompt.
+            # This repository's `translate_to_c` reads the annotated file, so
+            # an approach is to insert a comment with the sample diffs before
+            # calling `translate_one` again. For safety we do not mutate files
+            # automatically in this script unless explicitly requested.
+
+    click.secho("Iterations complete (no convergence).", fg="yellow")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gba_convert/linker.ld
+++ b/tools/gba_convert/linker.ld
@@ -1,0 +1,43 @@
+/* linker.ld — GBA ROM layout for rebuild.py
+ *
+ * The Luvdis-generated .s files each declare their own `.text` section
+ * starting at offset 0. When linked in module order (mod_0000, mod_0001,
+ * ...), they concatenate into a single .text that matches the original
+ * ROM's byte layout, because:
+ *
+ *   - rebuild.py's collect_source_files() globs annotated/mod_*.s and
+ *     passes them sorted by filename, which is also address order.
+ *   - Each mod_NNNN.s disassembles exactly its original byte span, so
+ *     the concatenated sizes match the ROM.
+ *
+ * If SHA-1 verification fails after a clean build (no splices), check:
+ *   (a) module ordering,
+ *   (b) .align padding introduced by thumb_func_start macros at module
+ *       boundaries (shouldn't happen if original functions were aligned),
+ *   (c) rodata emitted by your edited C (the splicer is text-only today).
+ */
+
+ENTRY(_08000000)
+
+MEMORY {
+    ROM (rx) : ORIGIN = 0x08000000, LENGTH = 32M
+}
+
+SECTIONS {
+    .text 0x08000000 : {
+        *(.text)
+        *(.text.*)
+        *(.rodata)
+        *(.rodata.*)
+        *(.data)
+        *(.data.*)
+    } > ROM
+
+    /DISCARD/ : {
+        *(.comment)
+        *(.note.*)
+        *(.ARM.attributes)
+        *(.ARM.exidx*)
+        *(.debug_*)
+    }
+}

--- a/tools/gba_convert/pipeline.py
+++ b/tools/gba_convert/pipeline.py
@@ -46,6 +46,10 @@ DEFAULT_OUTPUT = HERE / "output"
               help="Run disasm + split + analyze, skip the C-view step.")
 @click.option("--force", is_flag=True,
               help="Re-run completed modules in LLM steps.")
+@click.option("--include-data", is_flag=True,
+              help="Run LLM steps on pure-data modules too. "
+                   "By default kind=data modules are skipped — they're "
+                   "just `.byte` dumps and waste calls.")
 def main(
     rom: Path,
     output: Path,
@@ -56,6 +60,7 @@ def main(
     skip_analyze: bool,
     skip_cview: bool,
     force: bool,
+    include_data: bool,
 ) -> None:
     """Disassemble ROM, split, annotate with Claude, translate to C."""
     output.mkdir(parents=True, exist_ok=True)
@@ -107,8 +112,13 @@ def main(
             )
             sys.exit(2)
         modules = json.loads(modules_path.read_text())
+        n_data = sum(1 for m in modules if m.get("kind") == "data")
+        if not include_data and n_data:
+            click.echo(f"  skipping {n_data} data-only modules "
+                       f"(pass --include-data to override)")
         analyzer = Analyzer(output, model=model)
-        results = analyzer.analyze_all(modules, force=force)
+        results = analyzer.analyze_all(modules, force=force,
+                                       skip_data=not include_data)
         click.echo(f"  analysed {len(results)} new modules")
         click.echo(f"  variables: {analyzer.variables_md_path}")
         click.echo(f"  functions: {analyzer.functions_cfg_path}")
@@ -137,8 +147,13 @@ def main(
             )
             sys.exit(2)
         modules = json.loads(modules_path.read_text())
+        n_data = sum(1 for m in modules if m.get("kind") == "data")
+        if not include_data and n_data:
+            click.echo(f"  skipping {n_data} data-only modules "
+                       f"(pass --include-data to override)")
         translator = CTranslator(output, model=model)
-        results = translator.translate_all(modules, force=force)
+        results = translator.translate_all(modules, force=force,
+                                           skip_data=not include_data)
         click.echo(f"  translated {len(results)} new modules")
         click.echo(f"  c_view:    {translator.c_dir}")
         click.echo(f"  gba.h:     {translator.gba_h_path}")

--- a/tools/gba_convert/pipeline.py
+++ b/tools/gba_convert/pipeline.py
@@ -50,6 +50,9 @@ DEFAULT_OUTPUT = HERE / "output"
               help="Run LLM steps on pure-data modules too. "
                    "By default kind=data modules are skipped — they're "
                    "just `.byte` dumps and waste calls.")
+@click.option("--limit", type=int, default=None,
+              help="Process at most N modules in each LLM step. "
+                   "Useful for smoke-testing the pipeline cheaply.")
 def main(
     rom: Path,
     output: Path,
@@ -61,6 +64,7 @@ def main(
     skip_cview: bool,
     force: bool,
     include_data: bool,
+    limit: int | None,
 ) -> None:
     """Disassemble ROM, split, annotate with Claude, translate to C."""
     output.mkdir(parents=True, exist_ok=True)
@@ -116,8 +120,12 @@ def main(
         if not include_data and n_data:
             click.echo(f"  skipping {n_data} data-only modules "
                        f"(pass --include-data to override)")
+        candidates = modules if include_data else [m for m in modules if m.get("kind") != "data"]
+        if limit is not None:
+            candidates = candidates[:limit]
+            click.echo(f"  --limit {limit} → processing first {len(candidates)} of {len(modules)} modules")
         analyzer = Analyzer(output, model=model)
-        results = analyzer.analyze_all(modules, force=force,
+        results = analyzer.analyze_all(candidates, force=force,
                                        skip_data=not include_data)
         click.echo(f"  analysed {len(results)} new modules")
         click.echo(f"  variables: {analyzer.variables_md_path}")
@@ -151,8 +159,12 @@ def main(
         if not include_data and n_data:
             click.echo(f"  skipping {n_data} data-only modules "
                        f"(pass --include-data to override)")
+        candidates = modules if include_data else [m for m in modules if m.get("kind") != "data"]
+        if limit is not None:
+            candidates = candidates[:limit]
+            click.echo(f"  --limit {limit} → processing first {len(candidates)} of {len(modules)} modules")
         translator = CTranslator(output, model=model)
-        results = translator.translate_all(modules, force=force,
+        results = translator.translate_all(candidates, force=force,
                                            skip_data=not include_data)
         click.echo(f"  translated {len(results)} new modules")
         click.echo(f"  c_view:    {translator.c_dir}")

--- a/tools/gba_convert/pipeline.py
+++ b/tools/gba_convert/pipeline.py
@@ -1,0 +1,177 @@
+"""Top-level orchestrator: disasm → split → analyze.
+
+Usage:
+    python pipeline.py ROM.gba
+    python pipeline.py ROM.gba --skip-analyze
+    python pipeline.py ROM.gba --only analyze --force
+
+Env:
+    ANTHROPIC_API_KEY must be set for the analyze step.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import click
+
+from disassemble import disassemble
+from split_modules import split_asm
+from analyze import Analyzer, MODEL
+from translate_to_c import CTranslator
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = HERE / "output"
+
+
+@click.command()
+@click.argument("rom", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--output", type=click.Path(path_type=Path), default=DEFAULT_OUTPUT,
+              help="Output directory (default: tools/gba_convert/output).")
+@click.option("--default-mode", type=click.Choice(["BYTE", "THUMB", "WORD"]),
+              default="BYTE", show_default=True,
+              help="Luvdis default mode for unknown addresses.")
+@click.option("--max-lines", type=int, default=1500, show_default=True,
+              help="Max lines per module chunk.")
+@click.option("--model", default=MODEL, show_default=True,
+              help="Anthropic model ID for the analyze step.")
+@click.option("--only", type=click.Choice(["disasm", "split", "analyze", "cview"]),
+              default=None, help="Run only one phase.")
+@click.option("--skip-analyze", is_flag=True,
+              help="Run disasm + split, skip all LLM steps.")
+@click.option("--skip-cview", is_flag=True,
+              help="Run disasm + split + analyze, skip the C-view step.")
+@click.option("--force", is_flag=True,
+              help="Re-run completed modules in LLM steps.")
+def main(
+    rom: Path,
+    output: Path,
+    default_mode: str,
+    max_lines: int,
+    model: str,
+    only: str | None,
+    skip_analyze: bool,
+    skip_cview: bool,
+    force: bool,
+) -> None:
+    """Disassemble ROM, split, annotate with Claude, translate to C."""
+    output.mkdir(parents=True, exist_ok=True)
+    _archive_if_new_rom(rom, output)
+
+    modules_path = output / "modules" / "_index.json"
+
+    if only in (None, "disasm"):
+        click.secho("== step 1: disassemble ==", fg="cyan", bold=True)
+        result = disassemble(
+            rom,
+            output,
+            default_mode=default_mode,
+            seed_config=output / "functions.cfg",
+        )
+        click.echo(f"  asm:   {result.asm_path}")
+        click.echo(f"  hash:  {result.rom_hash}")
+        click.echo(f"  info:  {result.rom_info.splitlines()[0] if result.rom_info else '(none)'}")
+        (output / "rom.hash.txt").write_text(result.rom_hash + "\n")
+        if only == "disasm":
+            return
+
+    if only in (None, "split"):
+        click.secho("== step 2: split into modules ==", fg="cyan", bold=True)
+        mods = split_asm(
+            asm_path=output / "rom.s",
+            modules_dir=output / "modules",
+            max_lines=max_lines,
+        )
+        click.echo(f"  wrote {len(mods)} modules to {output / 'modules'}")
+        if only == "split":
+            return
+
+    if skip_analyze or only == "split":
+        return
+
+    if only in (None, "analyze"):
+        click.secho("== step 3: analyze ==", fg="cyan", bold=True)
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            click.secho(
+                "  ANTHROPIC_API_KEY is not set. Export it and re-run with --only analyze.",
+                fg="red",
+            )
+            sys.exit(2)
+        if not modules_path.is_file():
+            click.secho(
+                f"  {modules_path} missing — run step 2 first.",
+                fg="red",
+            )
+            sys.exit(2)
+        modules = json.loads(modules_path.read_text())
+        analyzer = Analyzer(output, model=model)
+        results = analyzer.analyze_all(modules, force=force)
+        click.echo(f"  analysed {len(results)} new modules")
+        click.echo(f"  variables: {analyzer.variables_md_path}")
+        click.echo(f"  functions: {analyzer.functions_cfg_path}")
+
+    if skip_cview or only == "analyze":
+        return
+
+    if only in (None, "cview"):
+        click.secho("== step 4: translate to C ==", fg="cyan", bold=True)
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            click.secho(
+                "  ANTHROPIC_API_KEY is not set. Export it and re-run with --only cview.",
+                fg="red",
+            )
+            sys.exit(2)
+        if not modules_path.is_file():
+            click.secho(
+                f"  {modules_path} missing — run step 2 first.",
+                fg="red",
+            )
+            sys.exit(2)
+        if not (output / "annotated").is_dir():
+            click.secho(
+                "  output/annotated/ missing — run step 3 first.",
+                fg="red",
+            )
+            sys.exit(2)
+        modules = json.loads(modules_path.read_text())
+        translator = CTranslator(output, model=model)
+        results = translator.translate_all(modules, force=force)
+        click.echo(f"  translated {len(results)} new modules")
+        click.echo(f"  c_view:    {translator.c_dir}")
+        click.echo(f"  gba.h:     {translator.gba_h_path}")
+
+
+def _archive_if_new_rom(rom: Path, output: Path) -> None:
+    """If output/ was built from a different ROM, move it aside."""
+    import hashlib
+
+    hash_file = output / "rom.hash.txt"
+    if not hash_file.is_file():
+        return
+    old_hash = hash_file.read_text().strip()
+
+    h = hashlib.sha1()
+    with rom.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    new_hash = h.hexdigest()
+
+    if new_hash == old_hash:
+        return
+    archive = output.with_name(f"{output.name}.{old_hash[:8]}")
+    click.secho(
+        f"  ROM hash changed ({old_hash[:8]} → {new_hash[:8]}); "
+        f"archiving previous output to {archive.name}",
+        fg="yellow",
+    )
+    if archive.exists():
+        shutil.rmtree(archive)
+    output.rename(archive)
+    output.mkdir(parents=True, exist_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gba_convert/prompts/c_view.md
+++ b/tools/gba_convert/prompts/c_view.md
@@ -1,0 +1,132 @@
+# Module → C view request
+
+You are translating one ANNOTATED GBA assembly module into C. The C
+will be compiled by `arm-none-eabi-gcc` and is both a comprehension
+aid AND the edit surface for ROM modifications. Follow the rules
+below _in addition to_ the system prompt (`CLAUDE.md`).
+
+## Module metadata
+
+- **Source file:** `{module_path}`
+- **Address range:** `{addr_start}` – `{addr_end}`
+- **Kind:** `{kind}`   (code | data | mixed)
+- **Lines in this module:** `{line_count}`
+
+## Current `variables.md`
+
+Use these names. Don't invent new ones for functions or globals that
+are already listed here.
+
+```markdown
+{variables_md}
+```
+
+## Shared `gba.h` (already exists; `#include` it)
+
+Provides:
+
+- Fixed-width typedefs: `u8`, `u16`, `u32`, `s8`, `s16`, `s32`.
+- `REG_*` macros for I/O registers (e.g. `REG_DISPCNT`, `REG_KEYINPUT`).
+- BIOS SWI wrappers (e.g. `bios_vblank_wait()`, `bios_div(num, denom)`).
+- Memory base constants: `EWRAM_BASE`, `IWRAM_BASE`, `VRAM_BASE`,
+  `OAM_BASE`, `PALETTE_BASE`, `ROM_BASE`, `SRAM_BASE`.
+
+Do not redeclare any of these. Just `#include "gba.h"`.
+
+## Annotated assembly
+
+```arm
+{module_source}
+```
+
+---
+
+## Translation rules
+
+1. **Compilability.** The C must build with:
+
+   ```sh
+   arm-none-eabi-gcc -mthumb -mcpu=arm7tdmi -Os \
+       -nostdlib -ffreestanding -Wall -c mod_XXXX.c
+   ```
+
+   No libc calls. No heap. No floating point unless the annotated ASM
+   was using soft-float helpers (then keep calling them as `extern`).
+
+2. **Types carry LDR/STR widths.** `ldrb` → `uint8_t`, `ldrh` →
+   `uint16_t`, `ldr` → `uint32_t`. Don't use `int` for everything;
+   the width is semantically important.
+
+3. **Use names from `variables.md`.** Function and global names must
+   match exactly. If `variables.md` calls something
+   `update_player_input`, use that.
+
+4. **Named I/O registers.** `*(volatile u16*)0x04000130` →
+   `REG_KEYINPUT`. Use the `REG_*` macros from `gba.h`.
+
+5. **BIOS calls use the wrapper.** `swi 0x06` → `bios_div(...)`.
+   Don't emit inline `__asm__("swi 0x06")` unless the calling
+   convention differs from the wrapper.
+
+6. **Backrefs on every non-trivial block.** Every translated function
+   body gets `// asm: mod_XXXX.s lines Y–Z` at the top, and any
+   non-obvious local block gets its own `// asm:` comment. This is
+   how a reviewer cross-checks the translation.
+
+7. **Hardware-specific semantics → inline asm.** If the original
+   depends on specific CPSR flag state, LDM/STM ordering for timing,
+   or other behaviour C can't express, emit a GCC extended-asm block
+   rather than fabricate wrong C:
+
+   ```c
+   __asm__ volatile (
+       "mov r0, %0\n\t"
+       "..."
+       : "=r"(result)
+       : "r"(input)
+       : "r0", "cc"
+   );
+   ```
+
+8. **Function signatures match the ABI.** AAPCS: args in `r0`–`r3`,
+   return in `r0`. If a function uses `r4`–`r11` they're local
+   variables (callee-saved). Don't over-declare arguments.
+
+9. **Data modules.** If `kind` is `data`, emit a C file that declares
+   the data as typed globals where you can infer the shape (e.g.
+   `const u16 palette_start[256]`). If the shape is opaque, emit
+   `extern const u8 mod_XXXX_raw[N];` and `#include` the raw bytes
+   verbatim via `.incbin` equivalents — don't try to turn 1500 lines
+   of `.byte` into C initialisers.
+
+10. **Don't fabricate.** If a region is `@ purpose unclear`, keep it
+    as a `// TODO:` comment with an inline asm block, don't invent a
+    plausible-looking C function that "does something like this."
+
+11. **No `main()`.** This module is linked into a full ROM; there's
+    no process entry point beyond the real entry point the analysis
+    step already identified.
+
+## Output format
+
+Respond with a **single JSON object**, no prose, no markdown fences:
+
+```json
+{{
+  "c_source": "string — the ENTIRE .c file contents, starting with the /* @source: ... */ header block and `#include \"gba.h\"`",
+  "gba_h_additions": [
+    {{
+      "name": "REG_SOMETHING",
+      "kind": "macro | typedef | extern | enum",
+      "definition": "full C declaration or #define line",
+      "reason": "why it's needed — short"
+    }}
+  ],
+  "notes": "one short paragraph of anything noteworthy: ambiguity in the ASM, assumptions made, data shapes guessed at. Empty string if nothing."
+}}
+```
+
+`c_source` is written verbatim to `output/c_view/<same-basename>.c`.
+`gba_h_additions` entries are appended to `output/c_view/gba.h` only
+if that exact `name` isn't already present. Use this field _sparingly_
+— if a REG is already in `gba.h`, don't re-add it.

--- a/tools/gba_convert/prompts/edit_apply.md
+++ b/tools/gba_convert/prompts/edit_apply.md
@@ -1,0 +1,64 @@
+# Apply a natural-language edit to one C module
+
+Rewrite the source below to carry out the user's request, while staying
+within the surgical-splice constraints. Return JSON only.
+
+## User's request
+
+> {instruction}
+
+## Module being edited: `{module_name}`
+
+```c
+{source}
+```
+
+## variables.md (naming context — use these names)
+
+```markdown
+{variables_md}
+```
+
+## Hard constraints
+
+1. **Compile-clean** with:
+
+   ```
+   arm-none-eabi-gcc -mthumb -mcpu=arm7tdmi -Os -nostdlib \
+       -ffreestanding -Wall -fno-builtin -c
+   ```
+
+2. **Signatures are immutable.** The splicer matches the edited function
+   to its original byte span by label. If you think the signature needs
+   to change to satisfy the request, leave a `// TODO:` comment
+   explaining why and keep the original signature.
+
+3. **Only `#include "gba.h"`.** No libc, no heap, no floats (unless the
+   original source already used soft-float helpers — then keep them as
+   `extern`).
+
+4. **Smaller binary = more likely to fit.** The edit has to slot into the
+   original byte span. Prefer branches over tables, constants over
+   computed values, simple loops over unrolled ones. If you need to
+   shrink: fewer locals, reuse registers, early-return paths.
+
+5. **Preserve `// asm:` backref comments** on functions and non-trivial
+   blocks — they're how the reviewer checks the translation.
+
+6. **No `main()`.** This module is linked into a full ROM.
+
+7. **Don't touch unrelated functions** in the module. If the edit only
+   concerns one function, leave the others byte-for-byte the same.
+
+## Output format
+
+Return a single JSON object, no prose around it, no markdown fences:
+
+```json
+{{
+  "c_source": "the FULL updated .c file, verbatim",
+  "notes": "one paragraph: what changed and why. Flag any concerns (size risk, semantic ambiguity)."
+}}
+```
+
+{retry_context}

--- a/tools/gba_convert/prompts/edit_target.md
+++ b/tools/gba_convert/prompts/edit_target.md
@@ -1,0 +1,39 @@
+# Route a natural-language edit to the right module
+
+You are picking which C module (in `output/c_view/`) a user's edit request
+is most likely about. Return JSON only, no prose.
+
+## User's request
+
+> {instruction}
+
+## variables.md (index of named functions + globals across the ROM)
+
+```markdown
+{variables_md}
+```
+
+## Available modules
+
+Each filename encodes `mod_<INDEX>_<START_ADDRESS>.c`.
+
+{module_list}
+
+## How to choose
+
+1. First, scan `variables.md` for function or global names that match the
+   user's description (by keyword or semantic intent).
+2. Each named entity has an address. Find the module whose range contains
+   that address (the filename's `<START_ADDRESS>` is the module's base).
+3. If multiple modules plausibly fit, list them most-likely-first.
+4. If nothing matches confidently, return an empty `candidates` list and
+   explain what you'd need to know.
+
+## Output
+
+```json
+{{
+  "candidates": ["mod_NNNN_ADDR.c", "..."],
+  "reasoning": "one sentence: why these"
+}}
+```

--- a/tools/gba_convert/prompts/module_analysis.md
+++ b/tools/gba_convert/prompts/module_analysis.md
@@ -1,0 +1,88 @@
+# Module analysis request
+
+You are analysing one module of a GBA disassembly. Follow the rules in
+the system prompt (`CLAUDE.md`). Use the existing `variables.md` to keep
+names consistent.
+
+## Module metadata
+
+- **File:** `{module_path}`
+- **Address range:** `{addr_start}` – `{addr_end}`
+- **Kind:** `{kind}`   (code | data | mixed)
+- **Lines in this chunk:** `{line_count}`
+
+## Current `variables.md`
+
+```markdown
+{variables_md}
+```
+
+## Module source
+
+```arm
+{module_source}
+```
+
+---
+
+## Output format
+
+Respond with **a single JSON object**, nothing else. No prose, no
+markdown fences. Schema:
+
+```json
+{{
+  "annotated_source": "string — the ENTIRE module file with @ comments added. Must still assemble. Preserve every original instruction, label, and directive exactly.",
+  "functions": [
+    {{
+      "address": "0x08XXXXXX",
+      "name": "PascalCaseName",
+      "mode": "thumb | arm",
+      "summary": "one short sentence",
+      "args": "r0 = ..., r1 = ...",
+      "returns": "r0 = ...",
+      "confidence": "high | medium"
+    }}
+  ],
+  "globals": [
+    {{
+      "address": "0x03XXXXXX",
+      "type": "u8 | u16 | u32 | ptr | struct",
+      "name": "snake_case_or_leave_empty",
+      "purpose": "short description",
+      "access": "read | write | rw",
+      "confidence": "high | medium"
+    }}
+  ],
+  "io_writes": [
+    {{
+      "register": "REG_DISPCNT",
+      "value_or_source": "#0x0140 | from r2",
+      "purpose": "enable mode 0 with BG0+BG1"
+    }}
+  ],
+  "constants": [
+    {{
+      "value": "0x1E",
+      "meaning": "frames per second",
+      "context": "sub_08001234 delay counter"
+    }}
+  ],
+  "notes": "one short paragraph of anything that didn't fit above — leave empty string if nothing"
+}}
+```
+
+## Rules for this response
+
+- Only include `functions` entries with `confidence: "high"` — these will
+  be written to `functions.cfg`. Medium-confidence names stay in
+  `variables.md` via `notes`.
+- If the module is pure data (`kind: data`), `annotated_source` may be
+  the original file unchanged, and `functions` will be empty — but still
+  fill `globals` / `constants` where the data clearly represents game
+  state (a level table, string pool, palette, etc.).
+- Do not emit an entry that's already in `variables.md` unchanged.
+  Only emit new information or corrections.
+- If you cannot analyse the module at all (e.g. it's corrupted or
+  entirely unknown bytes), return the object with empty arrays and
+  explain in `notes`.

--- a/tools/gba_convert/rebuild.py
+++ b/tools/gba_convert/rebuild.py
@@ -82,42 +82,37 @@ def collect_source_files(
 
 
 def assemble(src: Path, obj: Path) -> None:
-    """
-    TODO implement:
-
-        arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork \
-            -o <obj> <src>
-
-    Returns nothing on success, raises CalledProcessError on failure.
-    """
-    raise NotImplementedError(
-        "assemble() — fill in with arm-none-eabi-as invocation. "
-        "See PROCESS.md §11a step 1."
-    )
+    """arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork -o <obj> <src>."""
+    cmd = [
+        "arm-none-eabi-as",
+        "-mcpu=arm7tdmi",
+        "-mthumb-interwork",
+        "-o", str(obj),
+        str(src),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
 def link(objects: list[Path], elf_out: Path, linker_script: Path) -> None:
-    """
-    TODO implement:
-
-        arm-none-eabi-ld -T <linker_script> -o <elf_out> <objects...>
-    """
-    raise NotImplementedError(
-        "link() — fill in with arm-none-eabi-ld invocation. "
-        "See PROCESS.md §11a step 2."
-    )
+    """arm-none-eabi-ld -T <linker_script> -o <elf_out> <objects...>."""
+    cmd = [
+        "arm-none-eabi-ld",
+        "-T", str(linker_script),
+        "-o", str(elf_out),
+        *[str(o) for o in objects],
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
 def objcopy_to_bin(elf: Path, bin_out: Path) -> None:
-    """
-    TODO implement:
-
-        arm-none-eabi-objcopy -O binary <elf> <bin_out>
-    """
-    raise NotImplementedError(
-        "objcopy_to_bin() — fill in with arm-none-eabi-objcopy. "
-        "See PROCESS.md §11a step 3."
-    )
+    """arm-none-eabi-objcopy -O binary <elf> <bin_out>."""
+    cmd = [
+        "arm-none-eabi-objcopy",
+        "-O", "binary",
+        str(elf),
+        str(bin_out),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
 def fix_header(rom: Path) -> None:

--- a/tools/gba_convert/rebuild.py
+++ b/tools/gba_convert/rebuild.py
@@ -1,0 +1,258 @@
+"""Step 5: rebuild a .gba from annotated (possibly spliced) assembly.
+
+See PROCESS.md §11a for the full design.
+
+Pipeline:
+    1. `arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork -o <o> <s>`
+       for every `.s` in `annotated/` (or `recompiled/` when splicing).
+    2. `arm-none-eabi-ld -T linker.ld -o rebuilt.elf *.o`
+    3. `arm-none-eabi-objcopy -O binary rebuilt.elf rebuilt.gba`
+    4. `gbafix rebuilt.gba` — recompute header checksum.
+    5. Compare SHA-1 of `rebuilt.gba` against `output/rom.hash.txt`.
+       Matching hash = Luvdis disassembly round-trips cleanly.
+
+STATUS: STUB. Toolchain detection + hash comparison + CLI are wired;
+the actual as/ld/objcopy calls raise NotImplementedError with the
+exact commands to fill in. When you're ready to implement, each
+`NotImplementedError` block is a drop-in target.
+"""
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = HERE / "output"
+DEFAULT_LINKER = HERE / "linker.ld"
+
+REQUIRED_TOOLS = ("arm-none-eabi-as", "arm-none-eabi-ld", "arm-none-eabi-objcopy")
+OPTIONAL_TOOLS = ("gbafix",)
+
+
+@dataclass
+class ToolchainCheck:
+    found: dict[str, str]
+    missing_required: list[str]
+    missing_optional: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing_required
+
+
+def check_toolchain() -> ToolchainCheck:
+    found: dict[str, str] = {}
+    missing_req: list[str] = []
+    missing_opt: list[str] = []
+    for tool in REQUIRED_TOOLS:
+        path = shutil.which(tool)
+        if path:
+            found[tool] = path
+        else:
+            missing_req.append(tool)
+    for tool in OPTIONAL_TOOLS:
+        path = shutil.which(tool)
+        if path:
+            found[tool] = path
+        else:
+            missing_opt.append(tool)
+    return ToolchainCheck(found, missing_req, missing_opt)
+
+
+def collect_source_files(
+    annotated_dir: Path,
+    recompiled_dir: Path | None,
+) -> list[Path]:
+    """Return the list of .s files to assemble, preferring recompiled/."""
+    annotated = sorted(annotated_dir.glob("mod_*.s"))
+    if not recompiled_dir or not recompiled_dir.is_dir():
+        return annotated
+
+    recompiled = {p.name: p for p in recompiled_dir.glob("mod_*.s")}
+    merged: list[Path] = []
+    for p in annotated:
+        merged.append(recompiled.get(p.name, p))
+    return merged
+
+
+def assemble(src: Path, obj: Path) -> None:
+    """
+    TODO implement:
+
+        arm-none-eabi-as -mcpu=arm7tdmi -mthumb-interwork \
+            -o <obj> <src>
+
+    Returns nothing on success, raises CalledProcessError on failure.
+    """
+    raise NotImplementedError(
+        "assemble() — fill in with arm-none-eabi-as invocation. "
+        "See PROCESS.md §11a step 1."
+    )
+
+
+def link(objects: list[Path], elf_out: Path, linker_script: Path) -> None:
+    """
+    TODO implement:
+
+        arm-none-eabi-ld -T <linker_script> -o <elf_out> <objects...>
+    """
+    raise NotImplementedError(
+        "link() — fill in with arm-none-eabi-ld invocation. "
+        "See PROCESS.md §11a step 2."
+    )
+
+
+def objcopy_to_bin(elf: Path, bin_out: Path) -> None:
+    """
+    TODO implement:
+
+        arm-none-eabi-objcopy -O binary <elf> <bin_out>
+    """
+    raise NotImplementedError(
+        "objcopy_to_bin() — fill in with arm-none-eabi-objcopy. "
+        "See PROCESS.md §11a step 3."
+    )
+
+
+def fix_header(rom: Path) -> None:
+    """Recompute the GBA header checksum. `gbafix` is optional — if it's
+    not on PATH, we skip silently but warn the user."""
+    if not shutil.which("gbafix"):
+        click.secho(
+            "  gbafix not on PATH; skipping header fix. "
+            "Install via `brew install gbafix` or `pip install gbafix`.",
+            fg="yellow",
+        )
+        return
+    subprocess.run(["gbafix", str(rom)], check=True)
+
+
+def sha1(path: Path) -> str:
+    h = hashlib.sha1()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@click.command()
+@click.option("--output", type=click.Path(path_type=Path), default=DEFAULT_OUTPUT,
+              show_default=True,
+              help="Output directory created by pipeline.py.")
+@click.option("--linker", type=click.Path(path_type=Path), default=DEFAULT_LINKER,
+              show_default=True,
+              help="Linker script for arm-none-eabi-ld.")
+@click.option("--splice/--no-splice", default=True, show_default=True,
+              help="If output/recompiled/ exists, prefer those over annotated/.")
+@click.option("--skip-gbafix", is_flag=True,
+              help="Don't re-checksum the ROM header after objcopy.")
+@click.option("--verify/--no-verify", default=True, show_default=True,
+              help="Compare SHA-1 of rebuilt.gba against the original ROM hash.")
+def main(
+    output: Path,
+    linker: Path,
+    splice: bool,
+    skip_gbafix: bool,
+    verify: bool,
+) -> None:
+    """Rebuild rebuilt.gba from the (possibly spliced) disassembly.
+
+    STUB: toolchain detection + file collection + verify work today.
+    Assembly/link/objcopy raise NotImplementedError — fill them in to
+    complete Milestone 3 (see PROCESS.md §9).
+    """
+    output = output.resolve()
+    annotated = output / "annotated"
+    recompiled = output / "recompiled"
+    build_dir = output / "build"
+    rebuilt = output / "rebuilt.gba"
+    elf = build_dir / "rebuilt.elf"
+
+    if not annotated.is_dir():
+        click.secho(f"  {annotated} missing — run pipeline step 3 first.", fg="red")
+        sys.exit(2)
+
+    click.secho("== toolchain check ==", fg="cyan", bold=True)
+    tc = check_toolchain()
+    for tool, path in tc.found.items():
+        click.echo(f"  ✓ {tool}: {path}")
+    for tool in tc.missing_required:
+        click.secho(f"  ✗ {tool}: MISSING (required)", fg="red")
+    for tool in tc.missing_optional:
+        click.secho(f"  ⚠ {tool}: missing (optional; checksum fix skipped)", fg="yellow")
+    if not tc.ok:
+        click.secho(
+            "  Install the ARM toolchain (macOS: "
+            "`brew install --cask gcc-arm-embedded`; "
+            "Linux: `apt install gcc-arm-none-eabi`).",
+            fg="red",
+        )
+        sys.exit(2)
+
+    if not linker.is_file():
+        click.secho(
+            f"  linker script {linker} missing — see linker.ld.example "
+            f"or PROCESS.md §11a.",
+            fg="red",
+        )
+        sys.exit(2)
+
+    click.secho("== collect sources ==", fg="cyan", bold=True)
+    sources = collect_source_files(annotated, recompiled if splice else None)
+    n_spliced = sum(1 for p in sources if recompiled.is_dir() and p.is_relative_to(recompiled))
+    click.echo(f"  {len(sources)} .s files "
+               f"({n_spliced} from recompiled/, {len(sources) - n_spliced} from annotated/)")
+    if not sources:
+        click.secho("  no sources found.", fg="red")
+        sys.exit(2)
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    # -------- assembly / link / objcopy --------
+    click.secho("== assemble ==", fg="cyan", bold=True)
+    objs: list[Path] = []
+    for s in sources:
+        o = build_dir / (s.stem + ".o")
+        assemble(s, o)   # TODO: implement
+        objs.append(o)
+
+    click.secho("== link ==", fg="cyan", bold=True)
+    link(objs, elf, linker)   # TODO: implement
+
+    click.secho("== objcopy ==", fg="cyan", bold=True)
+    objcopy_to_bin(elf, rebuilt)   # TODO: implement
+
+    if not skip_gbafix:
+        click.secho("== gbafix ==", fg="cyan", bold=True)
+        fix_header(rebuilt)
+
+    if verify:
+        click.secho("== verify ==", fg="cyan", bold=True)
+        hash_file = output / "rom.hash.txt"
+        if not hash_file.is_file():
+            click.secho("  no rom.hash.txt; skipping verify.", fg="yellow")
+        else:
+            expected = hash_file.read_text().strip()
+            actual = sha1(rebuilt)
+            if expected == actual:
+                click.secho(f"  ✓ SHA-1 matches original: {actual}", fg="green")
+            else:
+                click.secho(f"  ✗ SHA-1 MISMATCH", fg="red")
+                click.echo(f"    expected: {expected}")
+                click.echo(f"    actual:   {actual}")
+                click.secho(
+                    "  If you spliced in recompiled C, expect a mismatch "
+                    "(the edit is the point). If you built from annotated/ "
+                    "alone, this is a Luvdis / assembly-toolchain bug.",
+                    fg="yellow",
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gba_convert/recompile.py
+++ b/tools/gba_convert/recompile.py
@@ -25,6 +25,7 @@ NotImplementedError with the exact commands/steps to fill in.
 """
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -158,52 +159,153 @@ def extract_text_bin(obj: Path, bin_out: Path) -> None:
     subprocess.run(cmd, check=True, capture_output=True, text=True)
 
 
-def original_byte_span(annotated: Path, func_name: str) -> tuple[int, int, bytes]:
+_DIRECTIVE_WIDTH = {
+    ".byte": 1, ".db": 1,
+    ".2byte": 2, ".hword": 2, ".short": 2, ".half": 2,
+    ".4byte": 4, ".word": 4, ".long": 4, ".int": 4,
+}
+_FUNC_START_MACROS = (
+    "thumb_func_start",
+    "arm_func_start",
+    "non_word_aligned_thumb_func_start",
+)
+_FUNC_END_MACROS = ("thumb_func_end", "arm_func_end")
+_SKIP_DIRECTIVES = {
+    ".pool", ".text", ".syntax", ".type", ".size", ".global", ".globl",
+    ".thumb", ".arm", ".thumb_func", ".end", ".equ", ".set", ".if",
+    ".endif", ".else", ".ltorg", ".extern", ".section", ".data",
+    ".macro", ".endm", ".include", ".purgem",
+}
+_ALIGN_DIRECTIVES = {".align", ".balign", ".p2align"}
+_ZERO_DIRECTIVES = {".space", ".skip", ".zero"}
+_STR_DIRECTIVES = {".ascii": False, ".asciz": True, ".string": True}
+
+
+def original_byte_span(annotated: Path, func_name: str) -> tuple[int, int, int]:
+    """Locate `func_name`'s byte span in the annotated .s.
+
+    Returns (start_line, end_line, total_bytes) where:
+      - start_line is the zero-based index of the `func_name:` label line.
+      - end_line is the first line AFTER the span (exclusive).
+      - total_bytes is how many bytes the body between them assembles to.
+
+    The span ends at the next `*_func_start` macro, a plausible next
+    function label (`sub_XXX:`, `_0xADDR:`), or EOF.
+
+    Only the *count* is authoritative here; the real bytes come from
+    the original ROM and don't need to be recovered — all callers use
+    the count for budget enforcement.
     """
-    TODO implement:
+    lines = annotated.read_text().splitlines()
+    label_pat = re.compile(rf"^\s*{re.escape(func_name)}\s*:\s*(@.*)?$")
 
-    Locate the `.byte` / `.hword` / `.word` span in the annotated .s
-    that corresponds to `func_name` (the label) and return:
-        (start_line, end_line, original_bytes)
+    start = None
+    mode = "thumb"
+    for i, line in enumerate(lines):
+        if label_pat.match(line):
+            start = i
+            for j in range(max(0, i - 4), i):
+                prev = lines[j].strip()
+                if prev.startswith("arm_func_start"):
+                    mode = "arm"
+                elif prev.startswith(_FUNC_START_MACROS):
+                    mode = "thumb"
+            break
+    if start is None:
+        raise ValueError(
+            f"label {func_name!r} not found in {annotated.name}"
+        )
 
-    Strategy:
-        - Find the label `func_name:` (or `thumb_func_start func_name`).
-        - Walk forward until the next function label or .pool/.align
-          boundary.
-        - Assemble the literal bytes that appear on those lines.
+    next_func = re.compile(r"^\s*(?:" + "|".join(_FUNC_START_MACROS) + r")\b")
+    next_label = re.compile(r"^\s*(?:_0?[xX]?[0-9A-Fa-f]+|sub_[0-9A-Fa-f]+)\s*:")
 
-    See PROCESS.md §11b step 4 for the exact stopping rules.
-    """
-    raise NotImplementedError(
-        "original_byte_span() — locate the func's byte span in the "
-        "annotated .s. See PROCESS.md §11b step 4."
-    )
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if next_func.match(lines[i]) or next_label.match(lines[i]):
+            end = i
+            break
+
+    total = _count_bytes(lines[start + 1 : end], mode)
+    return start, end, total
+
+
+def _count_bytes(body: list[str], mode: str) -> int:
+    width_inst = 4 if mode == "arm" else 2
+    total = 0
+    for raw in body:
+        line = raw.split("@", 1)[0].strip()
+        if not line or line.endswith(":"):
+            continue
+        first = line.split()[0]
+        if first in _FUNC_START_MACROS or first in _FUNC_END_MACROS:
+            continue
+        if first.startswith("."):
+            directive = first
+            operand = line[len(first):].strip()
+            w = _DIRECTIVE_WIDTH.get(directive)
+            if w is not None:
+                ops = [x for x in operand.split(",") if x.strip()]
+                total += len(ops) * w
+                continue
+            if directive in _STR_DIRECTIVES:
+                total += _count_string_bytes(operand, _STR_DIRECTIVES[directive])
+                continue
+            if directive in _ZERO_DIRECTIVES:
+                n = operand.split(",")[0].strip()
+                try:
+                    total += int(n, 0)
+                except ValueError:
+                    pass
+                continue
+            if directive in _ALIGN_DIRECTIVES or directive in _SKIP_DIRECTIVES:
+                continue
+            continue
+        total += width_inst
+    return total
+
+
+def _count_string_bytes(operand: str, null_terminate: bool) -> int:
+    total = 0
+    for m in re.finditer(r'"((?:[^"\\]|\\.)*)"', operand):
+        s = re.sub(r"\\.", "X", m.group(1))
+        total += len(s)
+        if null_terminate:
+            total += 1
+    return total
+
+
+_BYTES_PER_LINE = 16
 
 
 def splice(
     annotated_src: Path,
     spliced_dst: Path,
-    func_name: str,
+    start_line: int,
+    end_line: int,
     new_bytes: bytes,
 ) -> None:
+    """Rewrite `annotated_src` into `spliced_dst` with lines
+    (start_line, end_line) replaced by the bytes of `new_bytes`
+    emitted as `.byte` directives. The label line at `start_line`
+    is kept verbatim; everything at `end_line` onward is kept verbatim.
+
+    Caller must have ensured len(new_bytes) == original span bytes
+    (padded with THUMB nops if needed).
     """
-    TODO implement:
+    lines = annotated_src.read_text().splitlines(keepends=True)
+    prefix = "".join(lines[: start_line + 1])
+    suffix = "".join(lines[end_line:])
 
-    Replace the bytes belonging to `func_name` in `annotated_src` with
-    `new_bytes`, writing the result to `spliced_dst`. Everything
-    outside the function's span is copied verbatim.
+    body_parts = ["\t@ --- recompiled by recompile.py ---\n"]
+    for i in range(0, len(new_bytes), _BYTES_PER_LINE):
+        chunk = new_bytes[i : i + _BYTES_PER_LINE]
+        body_parts.append(
+            "\t.byte " + ", ".join(f"0x{b:02X}" for b in chunk) + "\n"
+        )
+    body_parts.append("\t@ --- end recompiled ---\n")
 
-    Length contract (enforced by caller, re-check here defensively):
-        len(new_bytes) <= len(original_bytes)
-    Pad the tail with THUMB_NOP (0xC046) to hit the original length
-    exactly — the surrounding code assumes fixed offsets.
-
-    See PROCESS.md §11b steps 4–5.
-    """
-    raise NotImplementedError(
-        "splice() — rewrite the annotated .s with new_bytes in place "
-        "of func_name's original byte span. See PROCESS.md §11b step 5."
-    )
+    spliced_dst.parent.mkdir(parents=True, exist_ok=True)
+    spliced_dst.write_text(prefix + "".join(body_parts) + suffix)
 
 
 def recompile_one(
@@ -225,8 +327,8 @@ def recompile_one(
     # module bundles several, we'll need the LLM to mark which one changed.
     func_name = _guess_func_name(mod.edited_path)
 
-    start, end, original = original_byte_span(mod.annotated_path, func_name)
-    n_new, n_orig = len(new_bytes), len(original)
+    start, end, n_orig = original_byte_span(mod.annotated_path, func_name)
+    n_new = len(new_bytes)
 
     if n_new > n_orig:
         click.secho(
@@ -238,7 +340,7 @@ def recompile_one(
         raise click.ClickException(f"{mod.name}: over-size")
 
     if n_new < n_orig:
-        pad = (n_orig - n_new)
+        pad = n_orig - n_new
         if pad % 2 != 0:
             raise click.ClickException(
                 f"{mod.name}: odd-byte padding ({pad}); THUMB is 2-byte"
@@ -253,7 +355,7 @@ def recompile_one(
         click.echo(f"  ✓ {mod.name}: compiled {n_new}B (exact fit).")
 
     dst = recompiled_dir / mod.annotated_path.name
-    splice(mod.annotated_path, dst, func_name, new_bytes)   # TODO
+    splice(mod.annotated_path, dst, start, end, new_bytes)
 
 
 def _guess_func_name(edited_c: Path) -> str:

--- a/tools/gba_convert/recompile.py
+++ b/tools/gba_convert/recompile.py
@@ -1,0 +1,351 @@
+"""Step 4b: compile edited C modules and splice the fresh bytes back into
+the Luvdis disassembly.
+
+See PROCESS.md §11b for the full design.
+
+Pipeline (per edited module):
+    1. Detect edits:  diff `output/edited/mod_XXXX.c` against
+       `output/c_view/mod_XXXX.c`. No edits → nothing to do.
+    2. `arm-none-eabi-gcc -mthumb -mcpu=arm7tdmi -Os -nostdlib
+        -ffreestanding -c -o <obj> <edited.c>`
+    3. `arm-none-eabi-objcopy -O binary --only-section=.text <obj> <bin>`
+    4. Size check vs the original byte span from the annotated .s:
+         - N' == N : splice verbatim.
+         - N' <  N : splice + pad tail with `nop` (0x46C0) to N.
+         - N' >  N : FAIL LOUDLY. Caller must either shrink the edit or
+                     relocate the function (out of scope for the stub).
+    5. Rewrite the corresponding `annotated/mod_XXXX.s` into
+       `recompiled/mod_XXXX.s` with the edited function's `.byte` span
+       replaced by the freshly compiled bytes. Everything outside the
+       edited function stays byte-identical.
+
+STATUS: STUB. Toolchain detection + edit detection + CLI are wired;
+gcc invocation, section extraction, and splice logic raise
+NotImplementedError with the exact commands/steps to fill in.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_OUTPUT = HERE / "output"
+
+REQUIRED_TOOLS = (
+    "arm-none-eabi-gcc",
+    "arm-none-eabi-objcopy",
+    "arm-none-eabi-objdump",
+)
+
+GCC_FLAGS = (
+    "-mthumb",
+    "-mcpu=arm7tdmi",
+    "-Os",
+    "-nostdlib",
+    "-ffreestanding",
+    "-Wall",
+    "-fno-builtin",
+    "-c",
+)
+
+THUMB_NOP = b"\xc0\x46"   # `mov r8, r8` — canonical THUMB nop (0x46C0 LE)
+
+
+@dataclass
+class ToolchainCheck:
+    found: dict[str, str]
+    missing: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing
+
+
+@dataclass
+class EditedModule:
+    """One C module that has a matching edit in output/edited/."""
+    name: str                 # e.g. "mod_0017_080A1B30.c"
+    edited_path: Path         # output/edited/<name>
+    baseline_path: Path       # output/c_view/<name>
+    annotated_path: Path      # output/annotated/<name>.replace('.c', '.s')
+
+
+def check_toolchain() -> ToolchainCheck:
+    found: dict[str, str] = {}
+    missing: list[str] = []
+    for tool in REQUIRED_TOOLS:
+        path = shutil.which(tool)
+        if path:
+            found[tool] = path
+        else:
+            missing.append(tool)
+    return ToolchainCheck(found, missing)
+
+
+def detect_edited_modules(
+    edited_dir: Path,
+    c_view_dir: Path,
+    annotated_dir: Path,
+) -> list[EditedModule]:
+    """Find every `edited/*.c` whose bytes differ from its `c_view/` twin."""
+    if not edited_dir.is_dir():
+        return []
+    out: list[EditedModule] = []
+    for edited in sorted(edited_dir.glob("mod_*.c")):
+        baseline = c_view_dir / edited.name
+        annotated = annotated_dir / (edited.stem + ".s")
+        if not baseline.is_file():
+            click.secho(
+                f"  ⚠ {edited.name}: no c_view baseline; skipping.",
+                fg="yellow",
+            )
+            continue
+        if not annotated.is_file():
+            click.secho(
+                f"  ⚠ {edited.name}: no annotated/{annotated.name}; skipping.",
+                fg="yellow",
+            )
+            continue
+        if edited.read_bytes() == baseline.read_bytes():
+            continue
+        out.append(
+            EditedModule(
+                name=edited.name,
+                edited_path=edited,
+                baseline_path=baseline,
+                annotated_path=annotated,
+            )
+        )
+    return out
+
+
+def compile_module(src: Path, obj: Path, gba_h_dir: Path) -> None:
+    """arm-none-eabi-gcc <GCC_FLAGS> -I<gba_h_dir> -o <obj> <src>.
+
+    Raises subprocess.CalledProcessError on failure; .stderr carries
+    the gcc diagnostic verbatim so callers (e.g. edit.py) can feed it
+    back to the LLM.
+    """
+    cmd = [
+        "arm-none-eabi-gcc",
+        *GCC_FLAGS,
+        f"-I{gba_h_dir}",
+        "-o", str(obj),
+        str(src),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def extract_text_bin(obj: Path, bin_out: Path) -> None:
+    """arm-none-eabi-objcopy -O binary --only-section=.text <obj> <bin_out>.
+
+    Note: if an edit introduces `.rodata` we currently drop it. The
+    surgical splice model is text-only; a rodata-bearing edit needs
+    out-of-line relocation (PROCESS.md §11b future work).
+    """
+    cmd = [
+        "arm-none-eabi-objcopy",
+        "-O", "binary",
+        "--only-section=.text",
+        str(obj),
+        str(bin_out),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def original_byte_span(annotated: Path, func_name: str) -> tuple[int, int, bytes]:
+    """
+    TODO implement:
+
+    Locate the `.byte` / `.hword` / `.word` span in the annotated .s
+    that corresponds to `func_name` (the label) and return:
+        (start_line, end_line, original_bytes)
+
+    Strategy:
+        - Find the label `func_name:` (or `thumb_func_start func_name`).
+        - Walk forward until the next function label or .pool/.align
+          boundary.
+        - Assemble the literal bytes that appear on those lines.
+
+    See PROCESS.md §11b step 4 for the exact stopping rules.
+    """
+    raise NotImplementedError(
+        "original_byte_span() — locate the func's byte span in the "
+        "annotated .s. See PROCESS.md §11b step 4."
+    )
+
+
+def splice(
+    annotated_src: Path,
+    spliced_dst: Path,
+    func_name: str,
+    new_bytes: bytes,
+) -> None:
+    """
+    TODO implement:
+
+    Replace the bytes belonging to `func_name` in `annotated_src` with
+    `new_bytes`, writing the result to `spliced_dst`. Everything
+    outside the function's span is copied verbatim.
+
+    Length contract (enforced by caller, re-check here defensively):
+        len(new_bytes) <= len(original_bytes)
+    Pad the tail with THUMB_NOP (0xC046) to hit the original length
+    exactly — the surrounding code assumes fixed offsets.
+
+    See PROCESS.md §11b steps 4–5.
+    """
+    raise NotImplementedError(
+        "splice() — rewrite the annotated .s with new_bytes in place "
+        "of func_name's original byte span. See PROCESS.md §11b step 5."
+    )
+
+
+def recompile_one(
+    mod: EditedModule,
+    build_dir: Path,
+    recompiled_dir: Path,
+    gba_h_dir: Path,
+) -> None:
+    """Compile mod.edited_path, size-check, splice into recompiled_dir."""
+    obj = build_dir / (mod.edited_path.stem + ".o")
+    bin_ = build_dir / (mod.edited_path.stem + ".bin")
+    compile_module(mod.edited_path, obj, gba_h_dir)      # TODO
+    extract_text_bin(obj, bin_)                           # TODO
+
+    new_bytes = bin_.read_bytes()
+
+    # The edited function's name is the module's label — for v1 we assume
+    # one function per module (the common case for surgical edits). If a
+    # module bundles several, we'll need the LLM to mark which one changed.
+    func_name = _guess_func_name(mod.edited_path)
+
+    start, end, original = original_byte_span(mod.annotated_path, func_name)
+    n_new, n_orig = len(new_bytes), len(original)
+
+    if n_new > n_orig:
+        click.secho(
+            f"  ✗ {mod.name}: compiled size {n_new} > original {n_orig}. "
+            f"Edit must fit in the original span, or the function must "
+            f"be relocated (out of scope).",
+            fg="red",
+        )
+        raise click.ClickException(f"{mod.name}: over-size")
+
+    if n_new < n_orig:
+        pad = (n_orig - n_new)
+        if pad % 2 != 0:
+            raise click.ClickException(
+                f"{mod.name}: odd-byte padding ({pad}); THUMB is 2-byte"
+            )
+        new_bytes = new_bytes + THUMB_NOP * (pad // 2)
+        click.secho(
+            f"  ⚠ {mod.name}: compiled {n_new}B, padded with "
+            f"{pad}B of THUMB nops to match original {n_orig}B.",
+            fg="yellow",
+        )
+    else:
+        click.echo(f"  ✓ {mod.name}: compiled {n_new}B (exact fit).")
+
+    dst = recompiled_dir / mod.annotated_path.name
+    splice(mod.annotated_path, dst, func_name, new_bytes)   # TODO
+
+
+def _guess_func_name(edited_c: Path) -> str:
+    """Placeholder: strip `mod_NNNN_ADDR.c` → `sub_ADDR`.
+
+    The real implementation will parse the `/* @source: ... */` header
+    the translator writes and/or the label on the original annotated .s.
+    """
+    stem = edited_c.stem                     # mod_0017_080A1B30
+    parts = stem.split("_")
+    if len(parts) >= 3 and all(c in "0123456789abcdefABCDEF" for c in parts[-1]):
+        return f"sub_{parts[-1].lower()}"
+    return stem
+
+
+@click.command()
+@click.option("--output", type=click.Path(path_type=Path), default=DEFAULT_OUTPUT,
+              show_default=True,
+              help="Output directory created by pipeline.py.")
+@click.option("--only", "only_name", type=str, default=None,
+              help="Recompile just one module (e.g. mod_0017_080A1B30.c).")
+def main(output: Path, only_name: str | None) -> None:
+    """Compile edited C modules and splice the bytes into recompiled/.
+
+    STUB: toolchain + edit detection work today; gcc/objcopy/splice
+    calls raise NotImplementedError — fill them in to complete
+    Milestone 4 (see PROCESS.md §9).
+    """
+    output = output.resolve()
+    c_view = output / "c_view"
+    edited = output / "edited"
+    annotated = output / "annotated"
+    recompiled = output / "recompiled"
+    build = output / "build_c"
+
+    for required in (c_view, annotated):
+        if not required.is_dir():
+            click.secho(
+                f"  {required} missing — run pipeline steps 3 and 4 first.",
+                fg="red",
+            )
+            sys.exit(2)
+
+    click.secho("== toolchain check ==", fg="cyan", bold=True)
+    tc = check_toolchain()
+    for tool, path in tc.found.items():
+        click.echo(f"  ✓ {tool}: {path}")
+    for tool in tc.missing:
+        click.secho(f"  ✗ {tool}: MISSING", fg="red")
+    if not tc.ok:
+        click.secho(
+            "  Install the ARM toolchain (macOS: "
+            "`brew install --cask gcc-arm-embedded`; "
+            "Linux: `apt install gcc-arm-none-eabi`).",
+            fg="red",
+        )
+        sys.exit(2)
+
+    click.secho("== detect edits ==", fg="cyan", bold=True)
+    mods = detect_edited_modules(edited, c_view, annotated)
+    if only_name:
+        mods = [m for m in mods if m.name == only_name]
+    if not mods:
+        if not edited.is_dir():
+            click.secho(
+                f"  {edited} doesn't exist yet. Copy a file from "
+                f"c_view/ into edited/ and modify it to trigger a "
+                f"recompile.",
+                fg="yellow",
+            )
+        else:
+            click.secho("  no edits detected (edited/ matches c_view/).",
+                        fg="yellow")
+        return
+    click.echo(f"  {len(mods)} edited module(s) to recompile:")
+    for m in mods:
+        click.echo(f"    - {m.name}")
+
+    recompiled.mkdir(parents=True, exist_ok=True)
+    build.mkdir(parents=True, exist_ok=True)
+
+    click.secho("== compile + splice ==", fg="cyan", bold=True)
+    for m in mods:
+        recompile_one(m, build_dir=build, recompiled_dir=recompiled,
+                      gba_h_dir=c_view)
+
+    click.secho(
+        f"\n  Done. Spliced modules in {recompiled}. "
+        f"Run `python rebuild.py` to turn them into a .gba.",
+        fg="green",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gba_convert/requirements.txt
+++ b/tools/gba_convert/requirements.txt
@@ -1,0 +1,4 @@
+anthropic>=0.40.0
+click>=8.0
+tqdm>=4.0
+click-default-group>=1.2

--- a/tools/gba_convert/split_modules.py
+++ b/tools/gba_convert/split_modules.py
@@ -1,0 +1,159 @@
+"""Step 2: split a Luvdis .s file into LLM-sized module chunks.
+
+Cuts on function directives (`thumb_func`, `arm_func`,
+`non_word_aligned_thumb_func`) and respects a max-lines ceiling. Each
+output module gets a header comment with its address range, source
+range, and inferred kind.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable
+
+FUNC_DIRECTIVE = re.compile(
+    r"^\s*(?:thumb_func_start|arm_func_start|non_word_aligned_thumb_func_start)\s+"
+)
+LABEL_ADDR = re.compile(r"^_?(sub|func|[A-Za-z_])\w*?_?([0-9A-Fa-f]{7,8}):")
+HEX_IN_COMMENT = re.compile(r"0[xX]([0-9A-Fa-f]{7,8})")
+DATA_DIRECTIVE = re.compile(r"^\s*\.(byte|hword|word|ascii|asciz|incbin|fill|space)\b")
+SECTION_DIRECTIVE = re.compile(r"^\s*\.section\b")
+
+
+@dataclass
+class Module:
+    index: int
+    addr_start: str
+    addr_end: str
+    src_line_start: int
+    src_line_end: int
+    kind: str  # "code" | "data" | "mixed"
+    path: str  # relative to modules dir
+
+
+def _extract_addr(line: str) -> str | None:
+    m = LABEL_ADDR.match(line.lstrip())
+    if m:
+        return f"0x{int(m.group(2), 16):08X}"
+    m = HEX_IN_COMMENT.search(line)
+    if m:
+        return f"0x{int(m.group(1), 16):08X}"
+    return None
+
+
+def _classify(lines: Iterable[str]) -> str:
+    code_hits = 0
+    data_hits = 0
+    for ln in lines:
+        s = ln.strip()
+        if not s or s.startswith("@"):
+            continue
+        if DATA_DIRECTIVE.match(ln):
+            data_hits += 1
+        elif FUNC_DIRECTIVE.match(ln) or s.endswith(":") or re.match(r"\s*[a-z]", ln):
+            code_hits += 1
+    if code_hits == 0 and data_hits > 0:
+        return "data"
+    if data_hits == 0 and code_hits > 0:
+        return "code"
+    return "mixed"
+
+
+def split_asm(
+    asm_path: Path,
+    modules_dir: Path,
+    *,
+    max_lines: int = 1500,
+) -> list[Module]:
+    modules_dir.mkdir(parents=True, exist_ok=True)
+    for old in modules_dir.glob("mod_*.s"):
+        old.unlink()
+
+    text = asm_path.read_text(errors="replace").splitlines(keepends=False)
+    boundaries: list[int] = []  # line indices where a chunk may begin
+    last = 0
+
+    for i, line in enumerate(text):
+        is_func = bool(FUNC_DIRECTIVE.match(line))
+        # Hard size cut: if we've gone max_lines without any boundary, cut
+        # at the next sensible spot (blank line or data-directive block).
+        if is_func or (i - last >= max_lines and (not line.strip() or DATA_DIRECTIVE.match(line))):
+            boundaries.append(i)
+            last = i
+
+    if not boundaries:
+        boundaries = [0]
+    if boundaries[0] != 0:
+        boundaries.insert(0, 0)
+    boundaries.append(len(text))  # sentinel
+
+    modules: list[Module] = []
+    idx = 0
+    cursor = 0  # current boundary index
+    while cursor < len(boundaries) - 1:
+        chunk_start_line = boundaries[cursor]
+        chunk_end_line = boundaries[cursor + 1]
+
+        # Expand until either size ceiling or no more boundaries.
+        next_cursor = cursor + 1
+        while (
+            next_cursor < len(boundaries) - 1
+            and (boundaries[next_cursor + 1] - chunk_start_line) <= max_lines
+        ):
+            next_cursor += 1
+            chunk_end_line = boundaries[next_cursor]
+
+        chunk_lines = text[chunk_start_line:chunk_end_line]
+        addr_start = _first_addr(chunk_lines) or "0x08000000"
+        addr_end = _last_addr(chunk_lines) or addr_start
+        kind = _classify(chunk_lines)
+
+        rel_name = f"mod_{idx:04d}_{addr_start[2:]}.s"
+        out_path = modules_dir / rel_name
+        header = (
+            f"@ Module: {rel_name}\n"
+            f"@ Range:  {addr_start} – {addr_end}\n"
+            f"@ Source: {asm_path.name} lines {chunk_start_line + 1}–{chunk_end_line}\n"
+            f"@ Kind:   {kind}\n"
+            f"@ Index:  {idx}\n"
+            f"@ ----------------------------------------------------------\n\n"
+        )
+        out_path.write_text(header + "\n".join(chunk_lines) + "\n")
+
+        modules.append(
+            Module(
+                index=idx,
+                addr_start=addr_start,
+                addr_end=addr_end,
+                src_line_start=chunk_start_line + 1,
+                src_line_end=chunk_end_line,
+                kind=kind,
+                path=rel_name,
+            )
+        )
+        idx += 1
+        cursor = next_cursor
+
+    index_path = modules_dir / "_index.json"
+    index_path.write_text(
+        json.dumps([asdict(m) for m in modules], indent=2) + "\n"
+    )
+    return modules
+
+
+def _first_addr(lines: list[str]) -> str | None:
+    for ln in lines:
+        a = _extract_addr(ln)
+        if a:
+            return a
+    return None
+
+
+def _last_addr(lines: list[str]) -> str | None:
+    for ln in reversed(lines):
+        a = _extract_addr(ln)
+        if a:
+            return a
+    return None

--- a/tools/gba_convert/translate_to_c.py
+++ b/tools/gba_convert/translate_to_c.py
@@ -56,12 +56,16 @@ class CTranslator:
         modules: list[dict],
         *,
         force: bool = False,
+        skip_data: bool = True,
     ) -> list[CViewResult]:
         progress = self._load_progress()
         results: list[CViewResult] = []
 
         for mod in modules:
             idx = mod["index"]
+            if skip_data and mod.get("kind") == "data":
+                progress.setdefault("skipped_data", []).append(idx)
+                continue
             if not force and idx in progress["completed"]:
                 continue
             annotated = self.annotated_dir / mod["path"]

--- a/tools/gba_convert/translate_to_c.py
+++ b/tools/gba_convert/translate_to_c.py
@@ -1,0 +1,257 @@
+"""Step 4: translate annotated ASM modules into C via Claude.
+
+Input:  output/annotated/*.s  +  output/variables.md
+Output: output/c_view/*.c     +  output/c_view/gba.h (accumulated)
+
+Read the PROCESS.md §4 and §10 before making changes. The resulting C
+must compile with `arm-none-eabi-gcc -mthumb -Os -nostdlib
+-ffreestanding`, because it's the edit surface for the surgical
+recompile path in §11b.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from anthropic import Anthropic
+
+HERE = Path(__file__).resolve().parent
+SYSTEM_PROMPT_PATH = HERE / "CLAUDE.md"
+PROMPT_TEMPLATE_PATH = HERE / "prompts" / "c_view.md"
+
+MODEL = "claude-opus-4-7"
+MAX_TOKENS = 16_000
+
+
+@dataclass
+class CViewResult:
+    module_index: int
+    c_path: Path
+    notes: str
+    header_additions: int
+
+
+class CTranslator:
+    def __init__(self, output_dir: Path, *, model: str = MODEL) -> None:
+        self.output_dir = output_dir
+        self.annotated_dir = output_dir / "annotated"
+        self.c_dir = output_dir / "c_view"
+        self.c_dir.mkdir(parents=True, exist_ok=True)
+        self.gba_h_path = self.c_dir / "gba.h"
+        self.variables_md_path = output_dir / "variables.md"
+        self.progress_path = output_dir / ".progress_c.json"
+
+        self.client = Anthropic()
+        self.model = model
+        self.system_prompt = SYSTEM_PROMPT_PATH.read_text()
+        self.template = PROMPT_TEMPLATE_PATH.read_text()
+
+        if not self.gba_h_path.exists():
+            self.gba_h_path.write_text(_GBA_H_SEED)
+
+    def translate_all(
+        self,
+        modules: list[dict],
+        *,
+        force: bool = False,
+    ) -> list[CViewResult]:
+        progress = self._load_progress()
+        results: list[CViewResult] = []
+
+        for mod in modules:
+            idx = mod["index"]
+            if not force and idx in progress["completed"]:
+                continue
+            annotated = self.annotated_dir / mod["path"]
+            if not annotated.is_file():
+                progress["skipped"][str(idx)] = f"no annotated file at {annotated}"
+                self._save_progress(progress)
+                continue
+            try:
+                result = self.translate_one(mod, annotated)
+            except Exception as exc:
+                progress["errors"][str(idx)] = f"{type(exc).__name__}: {exc}"
+                self._save_progress(progress)
+                raise
+            results.append(result)
+            progress["completed"].append(idx)
+            progress["errors"].pop(str(idx), None)
+            self._save_progress(progress)
+
+        return results
+
+    def translate_one(self, mod: dict, annotated_path: Path) -> CViewResult:
+        source = annotated_path.read_text()
+        variables_md = self.variables_md_path.read_text()
+
+        user_prompt = self.template.format(
+            module_path=mod["path"],
+            addr_start=mod["addr_start"],
+            addr_end=mod["addr_end"],
+            kind=mod["kind"],
+            line_count=len(source.splitlines()),
+            variables_md=variables_md,
+            module_source=source,
+        )
+
+        message = self.client.messages.create(
+            model=self.model,
+            max_tokens=MAX_TOKENS,
+            system=[
+                {
+                    "type": "text",
+                    "text": self.system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        raw = "".join(
+            block.text for block in message.content if block.type == "text"
+        )
+        parsed = _extract_json(raw)
+
+        c_source = parsed.get("c_source", "")
+        if not c_source.strip():
+            raise RuntimeError(f"module {mod['index']}: empty c_source from model")
+
+        c_path = self.c_dir / mod["path"].replace(".s", ".c")
+        c_path.write_text(c_source)
+
+        additions = parsed.get("gba_h_additions", []) or []
+        added = self._merge_gba_h(additions)
+
+        return CViewResult(
+            module_index=mod["index"],
+            c_path=c_path,
+            notes=parsed.get("notes", "") or "",
+            header_additions=added,
+        )
+
+    def _merge_gba_h(self, additions: list[dict]) -> int:
+        if not additions:
+            return 0
+        existing = self.gba_h_path.read_text()
+        appended: list[str] = []
+        for add in additions:
+            name = (add.get("name") or "").strip()
+            definition = (add.get("definition") or "").strip()
+            if not name or not definition:
+                continue
+            if re.search(rf"\b{re.escape(name)}\b", existing):
+                continue
+            block = [
+                f"/* {add.get('reason', '').strip() or 'added by translate_to_c'} */",
+                definition,
+                "",
+            ]
+            appended.append("\n".join(block))
+            existing += "\n" + block[0] + "\n" + block[1] + "\n"
+        if appended:
+            with self.gba_h_path.open("a") as fh:
+                fh.write("\n/* --- appended by translate_to_c --- */\n")
+                fh.write("\n".join(appended))
+        return len(appended)
+
+    def _load_progress(self) -> dict:
+        if self.progress_path.exists():
+            return json.loads(self.progress_path.read_text())
+        return {"completed": [], "errors": {}, "skipped": {}}
+
+    def _save_progress(self, progress: dict) -> None:
+        self.progress_path.write_text(json.dumps(progress, indent=2) + "\n")
+
+
+_JSON_OBJ = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _extract_json(raw: str) -> dict:
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```[a-zA-Z]*\n?", "", raw)
+        raw = re.sub(r"\n?```$", "", raw)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        m = _JSON_OBJ.search(raw)
+        if not m:
+            raise
+        return json.loads(m.group(0))
+
+
+_GBA_H_SEED = """/* gba.h — shared definitions for the C view.
+ *
+ * Written once by translate_to_c.py. Additions are appended by the
+ * translator when it encounters a register or wrapper not listed here.
+ * Hand-edit freely; the translator only _adds_, never rewrites.
+ */
+#ifndef GBA_CONVERT_GBA_H
+#define GBA_CONVERT_GBA_H
+
+#include <stdint.h>
+
+typedef uint8_t  u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef int8_t   s8;
+typedef int16_t  s16;
+typedef int32_t  s32;
+
+/* Memory region bases. */
+#define BIOS_BASE     0x00000000u
+#define EWRAM_BASE    0x02000000u
+#define IWRAM_BASE    0x03000000u
+#define IO_BASE       0x04000000u
+#define PALETTE_BASE  0x05000000u
+#define VRAM_BASE     0x06000000u
+#define OAM_BASE      0x07000000u
+#define ROM_BASE      0x08000000u
+#define SRAM_BASE     0x0E000000u
+
+/* LCD / display. */
+#define REG_DISPCNT   (*(volatile u16*)(IO_BASE + 0x000))
+#define REG_DISPSTAT  (*(volatile u16*)(IO_BASE + 0x004))
+#define REG_VCOUNT    (*(volatile u16*)(IO_BASE + 0x006))
+#define REG_BG0CNT    (*(volatile u16*)(IO_BASE + 0x008))
+#define REG_BG1CNT    (*(volatile u16*)(IO_BASE + 0x00A))
+#define REG_BG2CNT    (*(volatile u16*)(IO_BASE + 0x00C))
+#define REG_BG3CNT    (*(volatile u16*)(IO_BASE + 0x00E))
+
+/* Input. */
+#define REG_KEYINPUT  (*(volatile u16*)(IO_BASE + 0x130))
+#define REG_KEYCNT    (*(volatile u16*)(IO_BASE + 0x132))
+
+/* Interrupts. */
+#define REG_IE        (*(volatile u16*)(IO_BASE + 0x200))
+#define REG_IF        (*(volatile u16*)(IO_BASE + 0x202))
+#define REG_IME       (*(volatile u16*)(IO_BASE + 0x208))
+
+/* DMA source pointers (high halves of the 32-bit src/dst regs). */
+#define REG_DMA0SAD   (*(volatile u32*)(IO_BASE + 0x0B0))
+#define REG_DMA1SAD   (*(volatile u32*)(IO_BASE + 0x0BC))
+#define REG_DMA2SAD   (*(volatile u32*)(IO_BASE + 0x0C8))
+#define REG_DMA3SAD   (*(volatile u32*)(IO_BASE + 0x0D4))
+
+/* Timer 0 (others follow at +4/+8/+C). */
+#define REG_TM0CNT_L  (*(volatile u16*)(IO_BASE + 0x100))
+
+/* BIOS SWI wrappers. The actual SWI lives in ROM BIOS; the linker
+ * resolves these via the usual `ldr r*, =<addr>` pattern plus the
+ * GCC attribute below. */
+#define SWI_ATTR __attribute__((long_call, noinline))
+
+SWI_ATTR void bios_soft_reset(void);
+SWI_ATTR void bios_halt(void);
+SWI_ATTR void bios_vblank_wait(void);         /* swi 0x05 */
+SWI_ATTR s32  bios_div(s32 num, s32 denom);   /* swi 0x06, returns quotient */
+SWI_ATTR s32  bios_sqrt(u32 x);               /* swi 0x08 */
+SWI_ATTR void bios_cpu_set(const void *src, void *dst, u32 mode); /* 0x0B */
+SWI_ATTR void bios_cpu_fast_set(const void *src, void *dst, u32 mode); /* 0x0C */
+SWI_ATTR void bios_lz77_uncomp_wram(const void *src, void *dst);  /* 0x11 */
+SWI_ATTR void bios_lz77_uncomp_vram(const void *src, void *dst);  /* 0x12 */
+
+#endif /* GBA_CONVERT_GBA_H */
+"""

--- a/tools/gba_convert/translate_to_c.py
+++ b/tools/gba_convert/translate_to_c.py
@@ -15,14 +15,25 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from anthropic import Anthropic
+import os
+
+# Prefer a Gemini adapter when the GEMINI_API_KEY is present so users
+# can supply Gemini credentials instead of Anthropic. Fall back to the
+# installed Anthropic SDK if the adapter or key are not present.
+if os.environ.get("GEMINI_API_KEY"):
+    try:
+        from gemini_adapter import GeminiClient as Anthropic
+    except Exception:
+        from anthropic import Anthropic
+else:
+    from anthropic import Anthropic
 
 HERE = Path(__file__).resolve().parent
 SYSTEM_PROMPT_PATH = HERE / "CLAUDE.md"
 PROMPT_TEMPLATE_PATH = HERE / "prompts" / "c_view.md"
 
 MODEL = "claude-opus-4-7"
-MAX_TOKENS = 16_000
+MAX_TOKENS = 65_536
 
 
 @dataclass
@@ -86,7 +97,7 @@ class CTranslator:
 
         return results
 
-    def translate_one(self, mod: dict, annotated_path: Path) -> CViewResult:
+    def translate_one(self, mod: dict, annotated_path: Path, ghidra_hint: str = "") -> CViewResult:
         source = annotated_path.read_text()
         variables_md = self.variables_md_path.read_text()
 
@@ -99,6 +110,18 @@ class CTranslator:
             variables_md=variables_md,
             module_source=source,
         )
+
+        if ghidra_hint and ghidra_hint.strip():
+            user_prompt += (
+                "\n\n## Ghidra decompiler output (use as a starting point — correct it where needed)\n\n"
+                "```c\n"
+                + ghidra_hint.strip()
+                + "\n```\n"
+                "\nUse the Ghidra output above as structural guidance. "
+                "Fix types, variable names, register macros, and BIOS calls "
+                "as per the rules above. Do not copy Ghidra variable names "
+                "verbatim if they conflict with variables.md.\n"
+            )
 
         message = self.client.messages.create(
             model=self.model,
@@ -172,18 +195,113 @@ class CTranslator:
 _JSON_OBJ = re.compile(r"\{.*\}", re.DOTALL)
 
 
+def _fix_json_strings(raw: str) -> str:
+    """Attempt to repair unescaped control chars inside JSON string values.
+
+    LLMs often return JSON where the string values contain literal
+    newlines, tabs, or unescaped backslashes.  This helper walks the
+    raw text and escapes them so ``json.loads`` can succeed.
+    """
+    out: list[str] = []
+    in_string = False
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if not in_string:
+            if ch == '"':
+                in_string = True
+            out.append(ch)
+            i += 1
+        else:
+            if ch == '\\' and i + 1 < len(raw):
+                # already-escaped sequence — keep both chars
+                out.append(ch)
+                out.append(raw[i + 1])
+                i += 2
+            elif ch == '"':
+                in_string = False
+                out.append(ch)
+                i += 1
+            elif ch == '\n':
+                out.append('\\n')
+                i += 1
+            elif ch == '\r':
+                out.append('\\r')
+                i += 1
+            elif ch == '\t':
+                out.append('\\t')
+                i += 1
+            else:
+                out.append(ch)
+                i += 1
+    return "".join(out)
+
+
 def _extract_json(raw: str) -> dict:
     raw = raw.strip()
+    # strip markdown code fences
     if raw.startswith("```"):
         raw = re.sub(r"^```[a-zA-Z]*\n?", "", raw)
-        raw = re.sub(r"\n?```$", "", raw)
+        raw = re.sub(r"\n?```\s*$", "", raw)
+
+    # 1) Try direct parse
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
-        m = _JSON_OBJ.search(raw)
-        if not m:
-            raise
-        return json.loads(m.group(0))
+        pass
+
+    # 2) Extract outermost { … } and try
+    m = _JSON_OBJ.search(raw)
+    if m:
+        fragment = m.group(0)
+        try:
+            return json.loads(fragment)
+        except json.JSONDecodeError:
+            pass
+        # 3) Repair unescaped control characters and retry
+        try:
+            return json.loads(_fix_json_strings(fragment))
+        except json.JSONDecodeError:
+            pass
+
+    # 4) Try to salvage a truncated JSON response (max_tokens hit).
+    #    Look for "c_source": "..." and extract what we can.
+    salvage = re.search(r'"c_source"\s*:\s*"', raw)
+    if salvage:
+        start = salvage.end()
+        # walk the string collecting chars, handling escapes
+        chars: list[str] = []
+        i = start
+        while i < len(raw):
+            ch = raw[i]
+            if ch == '\\' and i + 1 < len(raw):
+                esc = raw[i + 1]
+                if esc == 'n': chars.append('\n')
+                elif esc == 't': chars.append('\t')
+                elif esc == 'r': chars.append('\r')
+                elif esc == '"': chars.append('"')
+                elif esc == '\\': chars.append('\\')
+                else: chars.append(ch + esc)
+                i += 2
+            elif ch == '"':
+                break  # proper end of string
+            else:
+                chars.append(ch)
+                i += 1
+        c_source = ''.join(chars)
+        if c_source.strip():
+            return {
+                "c_source": c_source,
+                "gba_h_additions": [],
+                "notes": "(salvaged from truncated JSON)",
+            }
+
+    # 5) Last resort: treat the entire response as raw C source.
+    return {
+        "c_source": raw,
+        "gba_h_additions": [],
+        "notes": "(raw LLM output — JSON extraction failed; treated as plain C)",
+    }
 
 
 _GBA_H_SEED = """/* gba.h — shared definitions for the C view.


### PR DESCRIPTION
Here's how iterative_loop.py works, step by step:

---

### Overview

It takes one module `.s` file (e.g. mod_0058_08000000.s) and repeatedly tries to produce C code whose compiled output is **byte-identical** to the original assembly bytes.

### The 4-stage loop

For each iteration (up to `--iterations N`):

**1. Extract ground truth** — `parse_module_bytes()` reads every `.byte`, `.hword`, `.word`, `.space` directive from the original `.s` and produces a raw byte array. This is the target to match.

**2. Decompile** — Produces a `.c` file using one of four `--mode` strategies:

| Mode | What happens |
|---|---|
| `dryrun` | Writes a stub C skeleton (no LLM, no Ghidra) |
| `llm` | Calls `CTranslator.translate_one()` which sends the assembly to Gemini/Claude and gets back C |
| `ghidra` | Builds a minimal ELF from the module bytes, imports it into Ghidra headless, runs the decompiler, and writes the raw C output |
| `ghidra_llm` | Runs Ghidra first to get a rough decompiler hint, then passes that hint + the assembly to the LLM for a refined C translation |

**3. Compile & extract** — If `--compile` is set:
- Compiles the `.c` with `arm-none-eabi-gcc -mthumb -mcpu=arm7tdmi -Os -nostdlib -ffreestanding`
- Extracts the `.text` section as raw binary via `objcopy`
- If `.text` is empty (data-only modules), falls back to extracting `.rodata`
- Auto-creates any missing raw `.bin` files that the C might reference via `.incbin`

**4. Compare** — `compare_bytes()` diffs the compiled binary against the ground truth:
- **0 differences** → prints "converged" and exits early
- **N differences** → prints a sample of mismatched offsets and continues to the next iteration

### Flow diagram

```
original .s ──parse_module_bytes()──► ground truth bytes
     │
     ▼
 [decompile]  ──► .c file
     │
     ▼
 [compile]    ──► .o ──objcopy──► .text/.rodata binary
     │
     ▼
 [compare]    ──► match? ──yes──► DONE (converged)
                    │
                    no
                    │
                    ▼
              next iteration
```

The key insight: for `mod_0058_08000000` (a pure data module), the LLM produced C that uses `.incbin` to embed the raw bytes in `.rodata`, which is why it converged in one iteration — the bytes pass through unchanged.